### PR TITLE
Sidebar Routing 설정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "@mui/material": "^7.0.1",
     "lucide-react": "^0.484.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-router:
+        specifier: ^7.4.1
+        version: 7.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -658,6 +661,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -856,6 +862,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -1363,6 +1373,16 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.4.1:
+    resolution: {integrity: sha512-Vmizn9ZNzxfh3cumddqv3kLOKvc7AskUT0dC1prTabhiEi0U4A33LmkDOJ79tXaeSqCqMBXBU/ySX88W85+EUg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -1415,6 +1435,9 @@ packages:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1496,6 +1519,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2139,6 +2165,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
+  '@types/cookie@0.6.0': {}
+
   '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.7': {}
@@ -2361,6 +2389,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -2845,6 +2875,16 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-router@7.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@types/cookie': 0.6.0
+      cookie: 1.0.2
+      react: 19.0.0
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+
   react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
@@ -2911,6 +2951,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3008,6 +3050,8 @@ snapshots:
       typescript: 5.7.3
 
   ts-interface-checker@0.1.13: {}
+
+  turbo-stream@2.4.0: {}
 
   type-check@0.4.0:
     dependencies:

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,8 @@
+import { RouterProvider } from "react-router";
+import { Router } from "./Router";
+
 function App() {
-  return <div className="flex h-screen">This is App</div>;
+  return <RouterProvider router={Router} />;
 }
 
 export default App;

--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter, Navigate } from "react-router";
+import { Layout } from "../widgets/layout/ui/Layout";
+import Dashboard from "../pages/dashboard";
+import Firmware from "../pages/firmware";
+import Advertisement from "../pages/advertisement";
+import Monitoring from "../pages/monitoring";
+
+export const Router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      // 초기 엔트리 경로를 dashboard로 지정
+      { index: true, element: <Navigate to="/dashboard" replace /> },
+      { path: "dashboard", element: <Dashboard /> },
+      { path: "firmware", element: <Firmware /> },
+      { path: "ads", element: <Advertisement /> },
+      { path: "monitoring", element: <Monitoring /> },
+    ],
+  },
+]);

--- a/frontend/src/widgets/layout/ui/Layout.tsx
+++ b/frontend/src/widgets/layout/ui/Layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router";
+import { SideBar } from "../../sidebar/ui/Sidebar";
+
+export const Layout = () => {
+  return (
+    <div className="flex h-screen">
+      <SideBar />
+      <main className="flex-1 p-4 overflow-y-auto">
+        <Outlet />
+      </main>
+    </div>
+  );
+};

--- a/frontend/src/widgets/sidebar/model/useNavigation.tsx
+++ b/frontend/src/widgets/sidebar/model/useNavigation.tsx
@@ -10,6 +10,7 @@ export interface NavigationItemType {
   id: string;
   icon: ReactNode;
   name: string;
+  path: string;
 }
 
 export const useNavigation = () => {
@@ -19,21 +20,25 @@ export const useNavigation = () => {
         id: "dashboard",
         icon: <LayoutDashboard />,
         name: "대시보드",
+        path: "/dashboard",
       },
       {
         id: "firmware",
         icon: <SquareTerminal />,
         name: "펌웨어 관리",
+        path: "/firmware",
       },
       {
         id: "ads",
         icon: <Megaphone />,
         name: "광고 관리",
+        path: "/ads",
       },
       {
         id: "monitoring",
         icon: <ChartColumn />,
         name: "모니터링",
+        path: "/monitoring",
       },
     ],
     []

--- a/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
@@ -1,13 +1,25 @@
+import { Link, useLocation } from "react-router";
 import { useNavigation } from "../model/useNavigation";
 import { NavigationItem } from "./NavigationItem";
 
 export const NavigationMenu = () => {
   const { navigationItems } = useNavigation();
 
+  // 현재 경로 계산, NavigationItem이 Active한지 판별하는데 사용
+  const location = useLocation();
+  const currentPath = location.pathname;
+
   return (
     <div className="flex flex-col items-start gap-12 px-16">
       {navigationItems.map((item) => (
-        <NavigationItem key={item.id} icon={item.icon} name={item.name} />
+        <Link to={item.path} key={item.id}>
+          <NavigationItem
+            key={item.id}
+            icon={item.icon}
+            name={item.name}
+            isActive={currentPath === item.path}
+          />
+        </Link>
       ))}
     </div>
   );


### PR DESCRIPTION
# Changelog
- Routing을 위한 `react-router` 패키지 추가
- Router 생성
  - `dashboard`, `firmware`, `ads`, `monitoring` 에 대한 path를 생성
  - 진입 지점은 `dashboard`로 설정
- `NavigationMenu`의 `NavigationItem`들의 path와 현재 경로가 같으면 `isActive` true 반환

# Testing
- 로컬에서 테스트
<img width="502" alt="image" src="https://github.com/user-attachments/assets/3db92ca8-c12e-4aa2-aad2-9b20666a5687" />

# Ops Impact
N/A

# Version Compatibility
N/A