### PR TITLE
Sidebar Navigation 메뉴 Padding 재설정

### DIFF
--- a/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
@@ -10,7 +10,7 @@ export const NavigationMenu = () => {
   const currentPath = location.pathname;
 
   return (
-    <div className="flex flex-col items-start gap-12 px-16">
+    <div className="flex flex-col items-start gap-12 pl-16">
       {navigationItems.map((item) => (
         <Link to={item.path} key={item.id}>
           <NavigationItem


### PR DESCRIPTION
# Changelog
- `NavigationMenu`의 padding을 왼쪽에만 적용

# Testing
<img width="235" alt="image" src="https://github.com/user-attachments/assets/2d92fa6e-4503-4b43-bce9-da441436c6a3" />

# Ops Impact
N/A

# Version Compatibility
N/A