### PR TITLE
Title Tile 추가 및 적용

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -1,9 +1,9 @@
 import { createBrowserRouter, Navigate } from "react-router";
 import { Layout } from "../widgets/layout/ui/Layout";
-import Dashboard from "../pages/dashboard";
-import Firmware from "../pages/firmware";
-import Advertisement from "../pages/advertisement";
-import Monitoring from "../pages/monitoring";
+import { Dashboard } from "../pages/dashboard";
+import { Firmware } from "../pages/firmware";
+import { Advertisement } from "../pages/advertisement";
+import { Monitoring } from "../pages/monitoring";
 
 export const Router = createBrowserRouter([
   {

--- a/frontend/src/pages/advertisement.tsx
+++ b/frontend/src/pages/advertisement.tsx
@@ -1,5 +1,9 @@
-const Advertisement = () => {
-  return <div>This is Advertisement page.</div>;
-};
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
-export default Advertisement;
+export const Advertisement = () => {
+  return (
+    <div>
+      <TitleTile title="광고 관리" description="광고 업로드 및 스케줄링" />
+    </div>
+  );
+};

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,5 +1,9 @@
-const Dashboard = () => {
-  return <div>This is Dashboard page.</div>;
-};
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
-export default Dashboard;
+export const Dashboard = () => {
+  return (
+    <div>
+      <TitleTile title="대시보드" description="디바이스 정보 및 최근 활동" />
+    </div>
+  );
+};

--- a/frontend/src/pages/firmware.tsx
+++ b/frontend/src/pages/firmware.tsx
@@ -1,5 +1,12 @@
-const Firmware = () => {
-  return <div>This is Firmware page.</div>;
-};
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
-export default Firmware;
+export const Firmware = () => {
+  return (
+    <div>
+      <TitleTile
+        title="펌웨어 관리"
+        description="펌웨어 업로드 및 원격 업데이트"
+      />
+    </div>
+  );
+};

--- a/frontend/src/pages/monitoring.tsx
+++ b/frontend/src/pages/monitoring.tsx
@@ -1,5 +1,9 @@
-const Monitoring = () => {
-  return <div>This is Monitoring Page</div>;
-};
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
-export default Monitoring;
+export const Monitoring = () => {
+  return (
+    <div>
+      <TitleTile title="모니터링" description="기기 상태 모니터링" />
+    </div>
+  );
+};

--- a/frontend/src/widgets/layout/ui/Layout.tsx
+++ b/frontend/src/widgets/layout/ui/Layout.tsx
@@ -5,7 +5,7 @@ export const Layout = () => {
   return (
     <div className="flex h-screen">
       <SideBar />
-      <main className="flex-1 p-4 overflow-y-auto">
+      <main className="flex-1 p-8 overflow-y-auto bg-slate-200">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/widgets/layout/ui/TitleTile.tsx
+++ b/frontend/src/widgets/layout/ui/TitleTile.tsx
@@ -1,0 +1,13 @@
+export interface TitleTileProps {
+  title: string;
+  description: string;
+}
+
+export const TitleTile = ({ title, description }: TitleTileProps) => {
+  return (
+    <div className="flex flex-col gap-2 p-8 bg-white rounded-lg text-neutral-600">
+      <p className="text-xl font-semibold">{title}</p>
+      <p className="text-sm">{description}</p>
+    </div>
+  );
+};


### PR DESCRIPTION
# Changelog
- 각 페이지 최상단에 표시될 `TitleTile` 타일 추가
  - Title & Description 표시
- 각 페이지에 `TitleTile` 컴포넌트 최상단에 추가
- Page에 `export default` 제거

# Testing
- 로컬 테스팅
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/999cb151-cec8-4ef5-898e-0519a5734c75" />

# Ops Impact
N/A

# Version Compatibility
N/A