### PR TITLE
TitleTile Font Weight 변경

### DIFF
--- a/frontend/src/widgets/layout/ui/TitleTile.tsx
+++ b/frontend/src/widgets/layout/ui/TitleTile.tsx
@@ -6,7 +6,7 @@ export interface TitleTileProps {
 export const TitleTile = ({ title, description }: TitleTileProps) => {
   return (
     <div className="flex flex-col gap-2 p-8 bg-white rounded-lg text-neutral-600">
-      <p className="text-xl font-semibold">{title}</p>
+      <p className="text-2xl font-medium">{title}</p>
       <p className="text-sm">{description}</p>
     </div>
   );


### PR DESCRIPTION
# Changelog
- TitleTile의 사이즈 & 두께 조정
  - #12 에서 폰트를 `Pretendard`로 변경하였는데 NanumSquareRound보다 두께가 훨씬 두꺼워짐

# Testing
**Before**
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/22ed9cd4-333c-44ae-8f88-faa1e2424ef9" />

**After**
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/67112856-3a0f-4693-9cdc-5f2426820957" />

# Ops Impact
N/A

# Version Compatibility
N/A