### PR TITLE
[Frontend] 메인 타일 생성

### DIFF
--- a/frontend/src/widgets/layout/ui/MainTile.tsx
+++ b/frontend/src/widgets/layout/ui/MainTile.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+export interface MainTileProps {
+  title: string;
+  rightElement?: ReactNode;
+  children?: ReactNode;
+}
+
+export const MainTile = ({ title, rightElement, children }: MainTileProps) => {
+  return (
+    <div className="flex flex-col p-8 bg-white rounded-md">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base text-neutral-600">{title}</h2>
+        {rightElement}
+      </div>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+};


### PR DESCRIPTION
# Changelog
- 페이지의 상세 내용들이 들어갈 메인 타일 생성
- `검색 바`, `전체 보기` 등 버튼을 추가하기 위한 `rightElement` 생성

# Testing
<img width="859" alt="image" src="https://github.com/user-attachments/assets/25afc67c-3c0c-4d1f-8180-949ad448e4d7" />

# Ops Impact
N/A

# Version Compatibility
N/A