### PR TITLE
[Frontend] 펌웨어 검색 기능 구현 & Mock API 추가

### DIFF
--- a/frontend/src/entities/firmware/api/api.ts
+++ b/frontend/src/entities/firmware/api/api.ts
@@ -1,7 +1,7 @@
 import { Firmware, FirmwareDto } from "../model/types";
 import { mapFirmwareDto } from "../model/mappers";
 import { apiClient } from "../../../shared/api/client";
-import { ApiReponse } from "../../../shared/api/types";
+import { ApiResponse } from "../../../shared/api/types";
 
 /**
  * Service responsible for handling firmware-related API requests
@@ -24,7 +24,7 @@ export const firmwareApiService = {
    */
   getAll: async (page: number = 1, limit: number = 10): Promise<Firmware[]> => {
     try {
-      const { data } = await apiClient.get<ApiReponse<FirmwareDto[]>>(
+      const { data } = await apiClient.get<ApiResponse<FirmwareDto[]>>(
         `/api/firmware`,
         { params: { page: page, limit: limit } }
       );
@@ -55,7 +55,7 @@ export const firmwareApiService = {
    */
   getOneById: async (id: number): Promise<Firmware | null> => {
     try {
-      const { data } = await apiClient.get<ApiReponse<FirmwareDto>>(
+      const { data } = await apiClient.get<ApiResponse<FirmwareDto>>(
         `api/firmware/${id}`
       );
 
@@ -78,7 +78,7 @@ export const firmwareApiService = {
    */
   search: async (query: string): Promise<Firmware[]> => {
     try {
-      const { data } = await apiClient.get<ApiReponse<FirmwareDto[]>>(
+      const { data } = await apiClient.get<ApiResponse<FirmwareDto[]>>(
         `/api/firmware/search`,
         { params: { query: query } }
       );

--- a/frontend/src/entities/firmware/api/api.ts
+++ b/frontend/src/entities/firmware/api/api.ts
@@ -65,4 +65,28 @@ export const firmwareApiService = {
       return null;
     }
   },
+
+  /**
+   * Searches for firmware based on a query string
+   * @async
+   * @param {string} query - The search query to filter firmware
+   * @returns {Promise<Firmware[]>} - A promise that resolves to an array of Firmware objects matching the query
+   * @throws Will log error and return empty array if API call fails
+   * @example
+   * // Search for firmware with version "1.0"
+   * const searchResults = await firmwareApiService.search("1.0");
+   */
+  search: async (query: string): Promise<Firmware[]> => {
+    try {
+      const { data } = await apiClient.get<ApiReponse<FirmwareDto[]>>(
+        `/api/firmware/search`,
+        { params: { query: query } }
+      );
+
+      return data.data.map(mapFirmwareDto);
+    } catch (error) {
+      console.error("Failed to search firmware:", error);
+      return [];
+    }
+  },
 };

--- a/frontend/src/features/firmware/api/useFirmwareSearch.tsx
+++ b/frontend/src/features/firmware/api/useFirmwareSearch.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { Firmware } from "../../../entities/firmware/model/types";
+import { firmwareApiService } from "../../../entities/firmware/api/api";
+
+/**
+ * Custom hook for searching firmware
+ * @function useFirmwareSearch
+ * @description This hook provides functionality to search for firmware by version.
+ * It manages the state of the firmware list, loading status, and error messages.
+ * It also provides a function to handle the search operation.
+ * @returns {firmwares: Firmware[], isLoading: boolean, error: string | null, handleSearch: (query: string) => void}
+ */
+export const useFirmwareSearch = () => {
+  const [firmwares, setFirmwares] = useState<Firmware[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async (query: string) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      if (!query.trim()) {
+        const allFirmwares = await firmwareApiService.getAll();
+        setFirmwares(allFirmwares);
+        return;
+      }
+
+      const results = await firmwareApiService.search(query);
+      setFirmwares(results);
+    } catch (err) {
+      setError("검색 중 오류가 발생했습니다.");
+      console.error("Error searching firmware:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    handleSearch("");
+  }, []);
+
+  return { firmwares, isLoading, error, handleSearch };
+};

--- a/frontend/src/pages/firmware.tsx
+++ b/frontend/src/pages/firmware.tsx
@@ -1,12 +1,32 @@
+import { FirmwareList } from "../entities/firmware/ui/FirmwareList";
+import { useFirmwareSearch } from "../features/firmware/api/useFirmwareSearch";
+import { SearchBar } from "../shared/ui/SearchBar";
+import { MainTile } from "../widgets/layout/ui/MainTile";
 import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
 export const Firmware = () => {
+  const { firmwares, isLoading, error, handleSearch } = useFirmwareSearch();
+
   return (
-    <div>
-      <TitleTile
-        title="펌웨어 관리"
-        description="펌웨어 업로드 및 원격 업데이트"
-      />
+    <div className="flex flex-col">
+      <div className="mb-8">
+        <TitleTile
+          title="펌웨어 관리"
+          description="펌웨어 업로드 및 원격 업데이트"
+        />
+      </div>
+      <div>
+        <MainTile
+          title="사용중인 펌웨어"
+          rightElement={<SearchBar onSearch={handleSearch} />}
+        >
+          <FirmwareList
+            firmwares={firmwares}
+            isLoading={isLoading}
+            error={error}
+          />
+        </MainTile>
+      </div>
     </div>
   );
 };

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -2,7 +2,7 @@
  * Generic API response wrapper
  * @template T Type of the data contained in the response
  */
-export interface ApiReponse<T> {
+export interface ApiResponse<T> {
   /** The main data payload returned from the API */
   data: T;
   /** Optional metadata  */

--- a/frontend/src/shared/mocks/handlers.ts
+++ b/frontend/src/shared/mocks/handlers.ts
@@ -51,6 +51,33 @@ export const handlers = [
     });
   }),
 
+  http.get("/api/firmware/search", ({ request }) => {
+    const url = new URL(request.url);
+    const query = url.searchParams.get("query") || "";
+    const page = parseInt(url.searchParams.get("page") || "1");
+    const limit = parseInt(url.searchParams.get("limit") || "10");
+    const startIdx = (page - 1) * limit;
+    const endIdx = page * limit;
+
+    const filteredFirmwares = firmwares.filter((firmware) =>
+      firmware.version.includes(query)
+    );
+
+    const paginatedData = filteredFirmwares.slice(startIdx, endIdx);
+    const total_count = filteredFirmwares.length;
+    const total_page = Math.ceil(total_count / limit);
+    const meta = {
+      page,
+      total_count,
+      limit,
+      total_page,
+    };
+    return HttpResponse.json({
+      data: paginatedData,
+      meta,
+    });
+  }),
+
   http.get("/api/firmware/:id", ({ params }) => {
     const id = parseInt(params.id as string);
 


### PR DESCRIPTION
# Changelog
- 펌웨어 API에 `search`를 추가하였습니다.
  - parameter에 `query=?`를 추가하면 해당 query를 포함하는 펌웨어 버전의 리스트를 반환합니다.
  - `useFirmwareSearch`라는 custom hook을 추가하여 검색 결과에 따라 펌웨어 리스트 state를 변경합니다.
  - MSW에 펌웨어 검색 API 핸들러를 추가하였습니다.

# Testing
https://github.com/user-attachments/assets/cec9a0bd-884b-4661-8c9d-7e9d55aeb062

# Ops Impact
N/A

# Version Compatibility
N/A