### PR TITLE
[Frontend] 버튼 컴포넌트 추가

### DIFF
--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -1,0 +1,41 @@
+import { JSX } from "react";
+
+/**
+ * Interface for Button component props
+ */
+export interface ButtonProps {
+  icon?: JSX.Element;
+  title: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * A reusable button component with consistent styling
+ * @param {ButtonProps} props - The component props
+ * @param {JSX.Element} [props.icon] - Optional icon to display inside the button
+ * @param {string} props.title - Text to dispaly inside the button
+ * @param {Function} [props.onClick] - Optional click handler function
+ * @param {boolean} [props.disabled] - Optional flag to disable the button
+ * @returns {JSX.Element} Rendered button component
+ */
+export const Button = ({
+  icon,
+  title,
+  onClick,
+  disabled,
+}: ButtonProps): JSX.Element => {
+  const disabledStyles = disabled
+    ? "opacity-60 cursor-not-allowed"
+    : "shadow-sm hover:shadow";
+
+  return (
+    <button
+      className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm text-white transition-all duration-200 rounded-md bg-slate-900 focus:ring-2 focus:ring-offset-2 ${disabledStyles}`}
+      onClick={onClick}
+    >
+      {icon && <span>{icon}</span>}
+      {title}
+    </button>
+  );
+};

--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -14,7 +14,7 @@ export interface ButtonProps {
  * A reusable button component with consistent styling
  * @param {ButtonProps} props - The component props
  * @param {JSX.Element} [props.icon] - Optional icon to display inside the button
- * @param {string} props.title - Text to dispaly inside the button
+ * @param {string} props.title - Text to display inside the button
  * @param {Function} [props.onClick] - Optional click handler function
  * @param {boolean} [props.disabled] - Optional flag to disable the button
  * @returns {JSX.Element} Rendered button component
@@ -33,6 +33,7 @@ export const Button = ({
     <button
       className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm text-white transition-all duration-200 rounded-md bg-slate-900 focus:ring-2 focus:ring-offset-2 ${disabledStyles}`}
       onClick={onClick}
+      disabled={disabled}
     >
       {icon && <span>{icon}</span>}
       {title}


### PR DESCRIPTION
# Changelog
- 여러 페이지에서 공통적으로 사용되는 `Button` 컴포넌트를 추가하였습니다.

# Testing
- Icon 없이 Title만 있는 경우
<img width="99" alt="image" src="https://github.com/user-attachments/assets/d3402942-5d2d-4e44-830a-e83f7bca43fd" />

- Icon, Title이 있는 경우
<img width="165" alt="image" src="https://github.com/user-attachments/assets/dd42f411-23cd-4c78-9555-3a81df36c9d8" />

- 클릭 시 ring 추가
<img width="176" alt="image" src="https://github.com/user-attachments/assets/86673b5f-9e8e-4116-b5af-8581a29c9fb2" />

- Disabled 된 경우
<img width="167" alt="image" src="https://github.com/user-attachments/assets/68aba63a-2604-405a-8d94-a8dd09003865" />

# Ops Impact
N/A

# Version Compatibility
N/A