### PR TITLE
[Frontend] 메인 타일 디자인 개선

### DIFF
--- a/frontend/src/widgets/layout/ui/MainTile.tsx
+++ b/frontend/src/widgets/layout/ui/MainTile.tsx
@@ -9,7 +9,7 @@ export interface MainTileProps {
 export const MainTile = ({ title, rightElement, children }: MainTileProps) => {
   return (
     <div className="flex flex-col p-8 bg-white rounded-md">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-8">
         <h2 className="text-base text-neutral-600">{title}</h2>
         {rightElement}
       </div>


### PR DESCRIPTION
# Changelog
- `Title`과 `Children` 간에 margin 4 -> 8 로 증가

# Testing
<img width="872" alt="image" src="https://github.com/user-attachments/assets/2002839f-f0ed-4853-9515-bcbccc9091e2" />

# Ops Impact
N/A

# Version Compatibility
N/A