### PR TITLE
[Frontend] 펌웨어 상세 정보 페이지 구현

### DIFF
--- a/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
@@ -2,6 +2,7 @@ import { Download } from "lucide-react";
 import { Button } from "../../../shared/ui/Button";
 import { Firmware } from "../model/types";
 import { JSX } from "react";
+import { LabeledValue } from "../../../shared/ui/LabeledValue";
 
 /**
  * Props interface for the FirmwareDetail component
@@ -38,32 +39,28 @@ export const FirmwareDetail = ({
   return (
     <div className="flex justify-between">
       <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-2">
-          <div className="text-sm font-normal text-neutral-600">
-            펌웨어 버전
-          </div>
-          <div className="text-base font-medium text-neutral-800">
-            {firmware?.version}
-          </div>
-        </div>
-        <div className="flex flex-col gap-2">
-          <div className="text-sm font-normal text-neutral-600">파일명</div>
-          <div className="text-base font-medium text-neutral-800">{`${firmware?.version}.ino`}</div>
-        </div>
-        <div className="flex flex-col gap-2">
-          <div className="text-sm font-normal text-neutral-600">
-            업로드 일자
-          </div>
-          <div className="text-base font-medium text-neutral-800">
-            {firmware?.createdAt.toLocaleString()}
-          </div>
-        </div>
+        <LabeledValue
+          label="펌웨어 버전"
+          value={firmware?.version ?? null}
+          size="sm"
+        />
+        <LabeledValue
+          label="파일명"
+          value={`${firmware?.version}.ino`}
+          size="sm"
+        />
+        <LabeledValue
+          label="업로드 일자"
+          value={firmware?.createdAt.toLocaleString() ?? null}
+          size="sm"
+        />
         <div className="self-start">
           <Button
             icon={<Download className="w-4" />}
             title="펌웨어 다운로드"
+            // TODO: Implement download functionality
             onClick={() => {}}
-            disabled={true}
+            disabled={false}
           />
         </div>
       </div>

--- a/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
@@ -1,0 +1,80 @@
+import { Download } from "lucide-react";
+import { Button } from "../../../shared/ui/Button";
+import { Firmware } from "../model/types";
+import { JSX } from "react";
+
+/**
+ * Props interface for the FirmwareDetail component
+ * @interface FirmwareDetailProps
+ * @property {Firmware | null} firmware - The firmware data to display
+ * @property {boolean} isLoading - Indicates if the firmware data is loading
+ * @property {string | null} error - Error message if loading firmware failed
+ */
+export interface FirmwareDetailProps {
+  firmware: Firmware | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Component that displays detailed information about a firmware
+ * @component
+ * @param {FirmwareDetailProps} props - Component props
+ * @returns {JSX.Element} Rendered component
+ */
+export const FirmwareDetail = ({
+  firmware,
+  isLoading,
+  error,
+}: FirmwareDetailProps): JSX.Element => {
+  if (isLoading) {
+    return <div className="flex justify-center py-8">로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div className="flex justify-center py-8">{error}</div>;
+  }
+
+  return (
+    <div className="flex justify-between">
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-2">
+          <div className="text-sm font-normal text-neutral-600">
+            펌웨어 버전
+          </div>
+          <div className="text-base font-medium text-neutral-800">
+            {firmware?.version}
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="text-sm font-normal text-neutral-600">파일명</div>
+          <div className="text-base font-medium text-neutral-800">{`${firmware?.version}.ino`}</div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="text-sm font-normal text-neutral-600">
+            업로드 일자
+          </div>
+          <div className="text-base font-medium text-neutral-800">
+            {firmware?.createdAt.toLocaleString()}
+          </div>
+        </div>
+        <div className="self-start">
+          <Button
+            icon={<Download className="w-4" />}
+            title="펌웨어 다운로드"
+            onClick={() => {}}
+            disabled={true}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col w-3/5 text-sm font-normal text-neutral-600">
+        <div className="mb-2 text-sm font-normal text-neutral-600">
+          릴리즈 노트
+        </div>
+        <div className="flex-1 p-2 overflow-auto text-sm font-normal border border-gray-200 rounded-lg shadow-sm text-neutral-800">
+          {firmware?.releaseNote}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/firmware/api/useFirmwareDetail.tsx
+++ b/frontend/src/features/firmware/api/useFirmwareDetail.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Firmware } from "../../../entities/firmware/model/types";
+import { firmwareApiService } from "../../../entities/firmware/api/api";
+
+/**
+ * Interface for the return value of the useFirmwareDetail hook
+ */
+export interface FirmwareDetailHookResult {
+  firmware: Firmware | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Custom React hook to fetch firmware details by ID
+ *
+ * This hook handles the API call to retrieve a specific firmware's details,
+ * manages loading states, and handles potential errors during the fetch process.
+ *
+ * @param {number | null} id - The ID of the firmware to fetch. If null, an error state will be set.
+ * @returns {FirmwareDetailHookResult} An object containing the firmware data, loading state, and any error messages
+ */
+export const useFirmwareDetail = (
+  id: number | null
+): FirmwareDetailHookResult => {
+  const [firmware, setFirmware] = useState<Firmware | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFirmware = async () => {
+      if (!id) {
+        setError("펌웨어 ID가 유효하지 않습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const result = await firmwareApiService.getOneById(id);
+        if (!result) {
+          setError("펌웨어를 찾을 수 없습니다.");
+          setIsLoading(false);
+          return;
+        }
+        setFirmware(result);
+      } catch (error) {
+        setError("펌웨어를 가져오는 중 오류가 발생했습니다.");
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFirmware();
+  }, [id]);
+
+  return { firmware, isLoading, error };
+};

--- a/frontend/src/pages/FirmwareDetailPage.tsx
+++ b/frontend/src/pages/FirmwareDetailPage.tsx
@@ -1,0 +1,52 @@
+import { useParams } from "react-router";
+import { useFirmwareDetail } from "../features/firmware/api/useFirmwareDetail";
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
+import { MainTile } from "../widgets/layout/ui/MainTile";
+import { FirmwareDetail } from "../entities/firmware/ui/FirmwareDetail";
+import { Button } from "../shared/ui/Button";
+
+/**
+ * FirmwareDetailPage component
+ *
+ * Renders a page displaying detailed information about a specific firmware.
+ * Uses the route parameter 'id' to fetch the firmware details.
+ *
+ * @component
+ * @returns {JSX.Element} The rendered firmware detail page
+ */
+export const FirmwareDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const parseId = id ? parseInt(id) : null;
+
+  const { firmware, isLoading, error } = useFirmwareDetail(parseId);
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-8">
+        <TitleTile
+          title="펌웨어 관리"
+          description="펌웨어 업로드 및 원격 업데이트"
+        />
+      </div>
+      <div>
+        <MainTile
+          title="펌웨어 세부 정보"
+          rightElement={
+            <Button
+              title="배포하기"
+              onClick={() => {
+                console.log("배포하기 클릭");
+              }}
+            />
+          }
+        >
+          <FirmwareDetail
+            firmware={firmware}
+            isLoading={isLoading}
+            error={error}
+          />
+        </MainTile>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
# Changelog
- 펌웨어 ID를 이용해 특정 펌웨어를 가져오는 Custom Hook `useFirmwareDetail`을 구현하였습니다.
- 펌웨어 상세 정보 페이지 컴포넌트 `FirmwareDetail`을 구현하였습니다.
- 펌웨어 상세 정보 페이지를 구현하였습니다.

# Testing
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/92ece224-c7db-476e-9f93-6c6862b2df74" />

# Ops Impact
N/A

# Version Compatibility
N/A