### PR TITLE
[Frontend] Firmware 상세 정보 페이지 Routing 구현

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -1,9 +1,10 @@
 import { createBrowserRouter, Navigate } from "react-router";
 import { Layout } from "../widgets/layout/ui/Layout";
 import { Dashboard } from "../pages/dashboard";
-import { Firmware } from "../pages/firmware";
+import { FirmwarePage } from "../pages/firmware";
 import { Advertisement } from "../pages/advertisement";
 import { Monitoring } from "../pages/monitoring";
+import { FirmwareDetailPage } from "../pages/FirmwareDetailPage";
 
 export const Router = createBrowserRouter([
   {
@@ -13,7 +14,8 @@ export const Router = createBrowserRouter([
       // 초기 엔트리 경로를 dashboard로 지정
       { index: true, element: <Navigate to="/dashboard" replace /> },
       { path: "dashboard", element: <Dashboard /> },
-      { path: "firmware", element: <Firmware /> },
+      { path: "firmware", element: <FirmwarePage /> },
+      { path: "firmware/:id", element: <FirmwareDetailPage /> },
       { path: "ads", element: <Advertisement /> },
       { path: "monitoring", element: <Monitoring /> },
     ],

--- a/frontend/src/entities/firmware/ui/FirmwareList.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareList.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import { Firmware } from "../model/types";
 
 /**
@@ -45,7 +46,8 @@ export const FirmwareList = ({
       ) : (
         <div className="divide-y divide-gray-100">
           {firmwares.map((firmware) => (
-            <div
+            <Link
+              to={`/firmware/${firmware.id}`}
               key={firmware.id}
               className="grid grid-cols-7 gap-4 p-4 transition-colors hover:bg-gray-50"
             >
@@ -58,7 +60,7 @@ export const FirmwareList = ({
               <div className="col-span-4 text-sm text-neutral-600">
                 {firmware.releaseNote}
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/frontend/src/pages/firmware.tsx
+++ b/frontend/src/pages/firmware.tsx
@@ -4,7 +4,7 @@ import { SearchBar } from "../shared/ui/SearchBar";
 import { MainTile } from "../widgets/layout/ui/MainTile";
 import { TitleTile } from "../widgets/layout/ui/TitleTile";
 
-export const Firmware = () => {
+export const FirmwarePage = () => {
   const { firmwares, isLoading, error, handleSearch } = useFirmwareSearch();
 
   return (

--- a/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
@@ -17,7 +17,7 @@ export const NavigationMenu = () => {
             key={item.id}
             icon={item.icon}
             name={item.name}
-            isActive={currentPath === item.path}
+            isActive={currentPath.startsWith(item.path)}
           />
         </Link>
       ))}


### PR DESCRIPTION
# Changelog
- `Router.tsx` 에 펌웨어 상세 정보 페이지를 추가하였습니다.
- 펌웨어 페이지에서 특정 펌웨어를 클릭하면 상세 정보 페이지로 라우팅되도록 하였습니다.
- 사이드바는 특정 URL로 시작하면 active 되도록 수정하였습니다. (아래 두개 모두 사이드바에 `펌웨어 관리`가 active되도록)
  - 펌웨어 페이지: `/firmware/`
  - 펌웨어 상세 페이지: `/firmware/:id`

# Testing
https://github.com/user-attachments/assets/9f6e357a-f3d5-41e3-83a3-ec8a73a648e7

# Ops Impact
N/A

# Version Compatibility
N/A