### PR TITLE
[Frontend] Firmware에 `updatedAt` 컬럼 추가

### DIFF
--- a/frontend/src/entities/firmware/model/mappers.ts
+++ b/frontend/src/entities/firmware/model/mappers.ts
@@ -12,6 +12,7 @@ export const mapFirmwareDto = (dto: FirmwareDto): Firmware => {
     version: dto.version,
     releaseNote: dto.release_note,
     createdAt: new Date(dto.created_at),
+    updatedAt: new Date(dto.updated_at),
     deviceCount: dto.device_count,
   };
 };

--- a/frontend/src/entities/firmware/model/types.ts
+++ b/frontend/src/entities/firmware/model/types.ts
@@ -6,6 +6,7 @@ export interface FirmwareDto {
   version: string;
   release_note: string;
   created_at: string;
+  updated_at: string;
   device_count: number;
 }
 
@@ -26,6 +27,7 @@ export interface Firmware {
   version: string;
   releaseNote: string;
   createdAt: Date;
+  updatedAt: Date;
   deviceCount: number;
 }
 

--- a/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
@@ -54,6 +54,11 @@ export const FirmwareDetail = ({
           value={firmware?.createdAt.toLocaleString() ?? null}
           size="sm"
         />
+        <LabeledValue
+          label="수정 일자"
+          value={firmware?.updatedAt.toLocaleString() ?? null}
+          size="sm"
+        />
         <div className="self-start">
           <Button
             icon={<Download className="w-4" />}

--- a/frontend/src/shared/mocks/handlers.ts
+++ b/frontend/src/shared/mocks/handlers.ts
@@ -6,6 +6,7 @@ const firmwares = [
     version: "24.04.01",
     release_note: "광고가 표시되지 않는 버그를 수정했습니다.",
     created_at: "2025-03-01T10:00:00",
+    updated_at: "2025-03-01T11:00:00",
     device_count: 1023,
   },
   {
@@ -13,6 +14,7 @@ const firmwares = [
     version: "24.04.02",
     release_note: "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다",
     created_at: "2025-03-02T11:00:00",
+    updated_at: "2025-03-02T12:00:00",
     device_count: 547,
   },
   {
@@ -20,6 +22,7 @@ const firmwares = [
     version: "24.04.03",
     release_note: "연두해요 연두 광고를 업로드하였습니다.",
     created_at: "2025-03-03T12:00:00",
+    updated_at: "2025-03-02T13:00:00",
     device_count: 219,
   },
   {
@@ -27,6 +30,7 @@ const firmwares = [
     version: "24.04.04",
     release_note: "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.",
     created_at: "2025-03-04T13:00:00",
+    updated_at: "2025-03-04T14:00:00",
     device_count: 1321,
   },
 ];


### PR DESCRIPTION
# Changelog
- `Firmware` 모델에 `updatedAt`(수정 일자) 컬럼을 추가하였습니다.

# Testing
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/dc36122d-f528-4bf9-89bf-ba02e15c3642" />

# Ops Impact
N/A

# Version Compatibility
N/A