### PR TITLE
[Frontend] Firmware 페이지네이션 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-paginate": "^8.3.0",
     "react-router": "^7.4.1"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-paginate:
+        specifier: ^8.3.0
+        version: 8.3.0(react@19.0.0)
       react-router:
         specifier: ^7.4.1
         version: 7.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1581,6 +1584,11 @@ packages:
 
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
+
+  react-paginate@8.3.0:
+    resolution: {integrity: sha512-TptZE37HPkT3R+7AszWA++LOTIsIHXcCSWMP9WW/abeF8sLpJzExFB/dVs7xbtqteJ5njF6kk+udTDC0AR3y5w==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18 || ^19
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -3341,6 +3349,11 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@19.1.0: {}
+
+  react-paginate@8.3.0(react@19.0.0):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.0.0
 
   react-refresh@0.14.2: {}
 

--- a/frontend/src/entities/firmware/api/api.ts
+++ b/frontend/src/entities/firmware/api/api.ts
@@ -1,7 +1,8 @@
-import { Firmware, FirmwareDto } from "../model/types";
+import { Firmware, FirmwareDto, PaginatedFirmware } from "../model/types";
 import { mapFirmwareDto } from "../model/mappers";
 import { apiClient } from "../../../shared/api/client";
-import { ApiResponse } from "../../../shared/api/types";
+import { ApiResponse, PaginatedApiResponse } from "../../../shared/api/types";
+import { mapPaginationMeta } from "../../../shared/api/mappers";
 
 /**
  * Service responsible for handling firmware-related API requests
@@ -22,17 +23,31 @@ export const firmwareApiService = {
    * // Get third page with 20 items per page
    * const firmwaresPage3 = await firmwareApiService.getAll(3, 20);
    */
-  getAll: async (page: number = 1, limit: number = 10): Promise<Firmware[]> => {
+  getAll: async (
+    page: number = 1,
+    limit: number = 10
+  ): Promise<PaginatedFirmware> => {
     try {
-      const { data } = await apiClient.get<ApiResponse<FirmwareDto[]>>(
+      const { data } = await apiClient.get<PaginatedApiResponse<FirmwareDto>>(
         `/api/firmware`,
         { params: { page: page, limit: limit } }
       );
 
-      return data.data.map(mapFirmwareDto);
+      return {
+        items: data.data.map(mapFirmwareDto),
+        paginationMeta: mapPaginationMeta(data.pagination),
+      };
     } catch (error) {
       console.error("Failed to fetch firmware list:", error);
-      return [];
+      return {
+        items: [],
+        paginationMeta: {
+          page: page,
+          totalCount: 0,
+          limit: limit,
+          totalPage: 1,
+        },
+      };
     }
   },
 
@@ -76,17 +91,32 @@ export const firmwareApiService = {
    * // Search for firmware with version "1.0"
    * const searchResults = await firmwareApiService.search("1.0");
    */
-  search: async (query: string): Promise<Firmware[]> => {
+  search: async (
+    query: string,
+    page: number = 1,
+    limit: number = 10
+  ): Promise<PaginatedFirmware> => {
     try {
-      const { data } = await apiClient.get<ApiResponse<FirmwareDto[]>>(
+      const { data } = await apiClient.get<PaginatedApiResponse<FirmwareDto>>(
         `/api/firmware/search`,
-        { params: { query: query } }
+        { params: { query: query, page: page, limit: limit } }
       );
 
-      return data.data.map(mapFirmwareDto);
+      return {
+        items: data.data.map(mapFirmwareDto),
+        paginationMeta: mapPaginationMeta(data.pagination),
+      };
     } catch (error) {
       console.error("Failed to search firmware:", error);
-      return [];
+      return {
+        items: [],
+        paginationMeta: {
+          page: page,
+          totalCount: 0,
+          limit: limit,
+          totalPage: 1,
+        },
+      };
     }
   },
 };

--- a/frontend/src/entities/firmware/api/api.ts
+++ b/frontend/src/entities/firmware/api/api.ts
@@ -14,7 +14,7 @@ export const firmwareApiService = {
    * @async
    * @param {number} [page=1] - The page number to retrieve
    * @param {number} [limit=10] - The number of items per page
-   * @returns {Promise<Firmware[]>} - A promise that resolves to an array of Firmware objects
+   * @returns {Promise<PaginatedFirmware>} - A promise that resolves to an array of Firmware objects
    * @throws Will log error and return empty array if API call fails
    * @example
    * // Get first page with default limit
@@ -85,7 +85,9 @@ export const firmwareApiService = {
    * Searches for firmware based on a query string
    * @async
    * @param {string} query - The search query to filter firmware
-   * @returns {Promise<Firmware[]>} - A promise that resolves to an array of Firmware objects matching the query
+   * @param {number} [page=1] - The page number to retrieve
+   * @param {number} [limit=10] - The number of items per page
+   * @returns {Promise<PaginatedFirmware>} - A promise that resolves to an array of Firmware objects matching the query
    * @throws Will log error and return empty array if API call fails
    * @example
    * // Search for firmware with version "1.0"

--- a/frontend/src/entities/firmware/model/types.ts
+++ b/frontend/src/entities/firmware/model/types.ts
@@ -1,3 +1,5 @@
+import { PaginationMeta } from "../../../shared/api/types";
+
 /**
  * Data transfer object for firmware from API
  */
@@ -8,15 +10,6 @@ export interface FirmwareDto {
   created_at: string;
   updated_at: string;
   device_count: number;
-}
-
-/**
- * Metadata for pagination from API
- */
-export interface MetaDto {
-  page: number;
-  total_count: number;
-  limit: number;
 }
 
 /**
@@ -31,10 +24,7 @@ export interface Firmware {
   deviceCount: number;
 }
 
-/**
- * Domain model for pagination metadata
- */
-export interface Meta {
-  page: number;
-  totalCount: number;
+export interface PaginatedFirmware {
+  items: Firmware[];
+  paginationMeta: PaginationMeta;
 }

--- a/frontend/src/pages/FirmwarePage.tsx
+++ b/frontend/src/pages/FirmwarePage.tsx
@@ -1,11 +1,25 @@
+import ReactPaginate from "react-paginate";
 import { FirmwareList } from "../entities/firmware/ui/FirmwareList";
 import { useFirmwareSearch } from "../features/firmware/api/useFirmwareSearch";
 import { SearchBar } from "../shared/ui/SearchBar";
 import { MainTile } from "../widgets/layout/ui/MainTile";
 import { TitleTile } from "../widgets/layout/ui/TitleTile";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export const FirmwarePage = () => {
-  const { firmwares, isLoading, error, handleSearch } = useFirmwareSearch();
+  const {
+    firmwares,
+    isLoading,
+    error,
+    pagination,
+    handleSearch,
+    handlePageChange,
+  } = useFirmwareSearch();
+
+  const handlePageClick = (event: { selected: number }) => {
+    const newPage = event.selected + 1; // ReactPaginate uses zero-based index
+    handlePageChange(newPage);
+  };
 
   return (
     <div className="flex flex-col">
@@ -25,6 +39,25 @@ export const FirmwarePage = () => {
             isLoading={isLoading}
             error={error}
           />
+
+          <div className="flex justify-center mt-6 text-neutral-500">
+            <ReactPaginate
+              previousLabel={<ChevronLeft size={18} />}
+              nextLabel={<ChevronRight size={18} />}
+              pageCount={pagination.totalPage}
+              onPageChange={handlePageClick}
+              forcePage={pagination.page - 1}
+              containerClassName="flex items-center space-x-3"
+              pageClassName="hover:text-black"
+              pageLinkClassName="text-sm px-2 py-1"
+              previousClassName="flex items-center hover:text-black"
+              nextClassName="flex items-center hover:text-black"
+              activeClassName="text-black font-semibold"
+              disabledClassName="opacity-50 cursor-not-allowed"
+              breakLabel="..."
+              breakClassName="px-2"
+            />
+          </div>
         </MainTile>
       </div>
     </div>

--- a/frontend/src/shared/api/mappers.ts
+++ b/frontend/src/shared/api/mappers.ts
@@ -1,0 +1,15 @@
+import { PaginationMeta, PaginationMetaDto } from "./types";
+
+/**
+ * Maps a PaginationMetaDto from the API to a PaginationMeta domain model
+ * @param dto - The metadata transfer object from the API
+ * @returns {PaginationMeta} The transformed metadata domain model
+ */
+export const mapPaginationMeta = (dto: PaginationMetaDto): PaginationMeta => {
+  return {
+    page: dto.page,
+    totalCount: dto.total_count,
+    limit: dto.limit,
+    totalPage: dto.total_page,
+  };
+};

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -5,8 +5,24 @@
 export interface ApiResponse<T> {
   /** The main data payload returned from the API */
   data: T;
-  /** Optional metadata  */
-  meta?: PaginationMeta;
+}
+
+export interface PaginatedApiResponse<T> {
+  /** The main data payload returned from the API */
+  data: T[];
+  /** Optional metadata for pagination */
+  pagination: PaginationMetaDto;
+}
+
+export interface PaginationMetaDto {
+  /** Current page number */
+  page: number;
+  /** Total number of items across all pages */
+  total_count: number;
+  /** Maximum number of items per page */
+  limit: number;
+  /** Total number of pages available */
+  total_page: number;
 }
 
 /**
@@ -19,4 +35,6 @@ export interface PaginationMeta {
   totalCount: number;
   /** Maximum number of items per page */
   limit: number;
+  /** Total number of pages available */
+  totalPage: number;
 }

--- a/frontend/src/shared/mocks/handlers.ts
+++ b/frontend/src/shared/mocks/handlers.ts
@@ -33,6 +33,78 @@ const firmwares = [
     updated_at: "2025-03-04T14:00:00",
     device_count: 1321,
   },
+  {
+    id: 5,
+    version: "24.04.05",
+    release_note: "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다",
+    created_at: "2025-03-05T14:00:00",
+    updated_at: "2025-03-05T15:00:00",
+    device_count: 547,
+  },
+  {
+    id: 6,
+    version: "24.04.06",
+    release_note: "연두해요 연두 광고를 업로드하였습니다.",
+    created_at: "2025-03-06T15:00:00",
+    updated_at: "2025-03-06T16:00:00",
+    device_count: 219,
+  },
+  {
+    id: 7,
+    version: "24.04.07",
+    release_note: "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.",
+    created_at: "2025-03-07T16:00:00",
+    updated_at: "2025-03-07T17:00:00",
+    device_count: 1321,
+  },
+  {
+    id: 8,
+    version: "24.04.08",
+    release_note: "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다",
+    created_at: "2025-03-08T17:00:00",
+    updated_at: "2025-03-08T18:00:00",
+    device_count: 547,
+  },
+  {
+    id: 9,
+    version: "24.04.09",
+    release_note: "연두해요 연두 광고를 업로드하였습니다.",
+    created_at: "2025-03-09T18:00:00",
+    updated_at: "2025-03-09T19:00:00",
+    device_count: 219,
+  },
+  {
+    id: 10,
+    version: "24.04.10",
+    release_note: "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.",
+    created_at: "2025-03-10T19:00:00",
+    updated_at: "2025-03-10T20:00:00",
+    device_count: 1321,
+  },
+  {
+    id: 11,
+    version: "24.04.11",
+    release_note: "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다",
+    created_at: "2025-03-11T20:00:00",
+    updated_at: "2025-03-11T21:00:00",
+    device_count: 547,
+  },
+  {
+    id: 12,
+    version: "24.04.12",
+    release_note: "연두해요 연두 광고를 업로드하였습니다.",
+    created_at: "2025-03-12T21:00:00",
+    updated_at: "2025-03-12T22:00:00",
+    device_count: 219,
+  },
+  {
+    id: 13,
+    version: "24.04.13",
+    release_note: "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.",
+    created_at: "2025-03-13T22:00:00",
+    updated_at: "2025-03-13T23:00:00",
+    device_count: 1321,
+  },
 ];
 
 export const handlers = [
@@ -45,13 +117,18 @@ export const handlers = [
     const endIdx = page * limit;
     const paginatedData = firmwares.slice(startIdx, endIdx);
 
+    const total_page = Math.ceil(firmwares.length / limit);
+    const total_count = firmwares.length;
+    const meta = {
+      page,
+      total_count,
+      limit,
+      total_page,
+    };
+
     return HttpResponse.json({
       data: paginatedData,
-      meta: {
-        page,
-        total_count: firmwares.length,
-        limit,
-      },
+      pagination: meta,
     });
   }),
 
@@ -78,7 +155,7 @@ export const handlers = [
     };
     return HttpResponse.json({
       data: paginatedData,
-      meta,
+      pagination: meta,
     });
   }),
 


### PR DESCRIPTION
# Changelog
- 간단한 Pagination 구현을 위해 `react-paginate` 라이브러리를 추가하였습니다.
- Paginated된 요청의 interface를 기존 `ApiResponse`와 분리하였습니다 -> `PaginatedApiResponse` 생성
  - Paginated Response는 여러 서비스에서 공통적으로 사용될 수 있으므로, `Firmware`에 있던 `Meta`를 삭제하고 `shared/api`에 추가하여 여러 서비스가 같은 `PaginationMeta` 를 사용할 수 있도록 하였습니다.
- Firmware 페이지의 펌웨어 리스트를 Pagination 적용하기 위해 `firmwareApiService`가 Paginated Meta를 반환하도록 수정하고, `useFirmwareSearch`에서 page의 상태를 저장하도록 하였습니다.

# Testing
https://github.com/user-attachments/assets/7295ae58-00bc-48f4-99f5-7182ea6b92b7

# Ops Impact
N/A

# Version Compatibility
N/A