### PR TITLE
[FrontEnd] Button 컴포넌트에 `variant` 속성 추가

### DIFF
--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
   title: string;
   onClick?: () => void;
   disabled?: boolean;
+  variant?: "primary" | "secondary";
 }
 
 /**
@@ -17,6 +18,7 @@ export interface ButtonProps {
  * @param {string} props.title - Text to display inside the button
  * @param {Function} [props.onClick] - Optional click handler function
  * @param {boolean} [props.disabled] - Optional flag to disable the button
+ * @param {string} [props.variant] - Optional variant for button styling
  * @returns {JSX.Element} Rendered button component
  */
 export const Button = ({
@@ -24,14 +26,20 @@ export const Button = ({
   title,
   onClick,
   disabled,
+  variant = "primary",
 }: ButtonProps): JSX.Element => {
   const disabledStyles = disabled
     ? "opacity-60 cursor-not-allowed"
     : "shadow-sm hover:shadow";
 
+  const variantStyles = {
+    primary: "bg-slate-900 text-white",
+    secondary: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+  };
+
   return (
     <button
-      className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm text-white transition-all duration-200 rounded-md bg-slate-900 focus:ring-2 focus:ring-offset-2 ${disabledStyles}`}
+      className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm transition-all duration-200 rounded-md focus:ring-2 focus:ring-offset-2 ${variantStyles[variant]} ${disabledStyles}`}
       onClick={onClick}
       disabled={disabled}
     >


### PR DESCRIPTION
# Changelog
- `Button` 컴포넌트에 `variant` 속성을 추가하여 primary & secondary 를 구분할 수 있도록 개선하였습니다.

# Testing
- 취소: `secondary`, 등록: `primary`
<img width="145" alt="image" src="https://github.com/user-attachments/assets/8a473462-71d2-4896-b5f3-170d8a2f7a2f" />

# Ops Impact
N/A

# Version Compatibility
N/A