### PR TITLE
[FrontEnd] Button 컴포넌트에 `type` 추가

### DIFF
--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -4,28 +4,31 @@ import { JSX } from "react";
  * Interface for Button component props
  */
 export interface ButtonProps {
-  icon?: JSX.Element;
   title: string;
+  icon?: JSX.Element;
   onClick?: () => void;
   disabled?: boolean;
+  type?: "button" | "submit" | "reset";
   variant?: "primary" | "secondary";
 }
 
 /**
  * A reusable button component with consistent styling
  * @param {ButtonProps} props - The component props
- * @param {JSX.Element} [props.icon] - Optional icon to display inside the button
  * @param {string} props.title - Text to display inside the button
+ * @param {JSX.Element} [props.icon] - Optional icon to display inside the button
  * @param {Function} [props.onClick] - Optional click handler function
  * @param {boolean} [props.disabled] - Optional flag to disable the button
+ * @param {string} [props.type] - Type of the button (default is "button")
  * @param {string} [props.variant] - Optional variant for button styling
  * @returns {JSX.Element} Rendered button component
  */
 export const Button = ({
-  icon,
   title,
+  icon,
   onClick,
   disabled,
+  type = "button",
   variant = "primary",
 }: ButtonProps): JSX.Element => {
   const disabledStyles = disabled
@@ -42,6 +45,7 @@ export const Button = ({
       className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm transition-all duration-200 rounded-md focus:ring-2 focus:ring-offset-2 ${variantStyles[variant]} ${disabledStyles}`}
       onClick={onClick}
       disabled={disabled}
+      type={type}
     >
       {icon && <span>{icon}</span>}
       {title}

--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
   title: string;
   onClick?: () => void;
   disabled?: boolean;
+  variant?: "primary" | "secondary";
 }
 
 /**
@@ -17,6 +18,7 @@ export interface ButtonProps {
  * @param {string} props.title - Text to display inside the button
  * @param {Function} [props.onClick] - Optional click handler function
  * @param {boolean} [props.disabled] - Optional flag to disable the button
+ * @param {string} [props.variant] - Optional variant for button styling
  * @returns {JSX.Element} Rendered button component
  */
 export const Button = ({
@@ -24,14 +26,20 @@ export const Button = ({
   title,
   onClick,
   disabled,
+  variant = "primary",
 }: ButtonProps): JSX.Element => {
   const disabledStyles = disabled
     ? "opacity-60 cursor-not-allowed"
     : "shadow-sm hover:shadow";
 
+  const variantStyles = {
+    primary: "bg-slate-900 text-white",
+    secondary: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+  };
+
   return (
     <button
-      className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm text-white transition-all duration-200 rounded-md bg-slate-900 focus:ring-2 focus:ring-offset-2 ${disabledStyles}`}
+      className={`px-4 py-1.5 flex gap-2 items-center justify-center text-sm transition-all duration-200 rounded-md focus:ring-2 focus:ring-offset-2 ${variantStyles[variant]} ${disabledStyles}`}
       onClick={onClick}
       disabled={disabled}
     >


### PR DESCRIPTION
# Changelog
- `Button`은 목적에 따라 `button`, `submit`, `reset`이 될 수 있으므로 이에 맞게 `type` props를 추가하였습니다.

# Testing
N/A

# Ops Impact
N/A

# Version Compatibility
N/A