### PR TITLE
[FrontEnd] Firmware 등록 모달 창 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-modal": "^3.16.3",
     "react-paginate": "^8.3.0",
     "react-router": "^7.4.1"
   },
@@ -25,6 +26,7 @@
     "@eslint/js": "^9.21.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/react-modal": "^3.16.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.21.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-modal:
+        specifier: ^3.16.3
+        version: 3.16.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-paginate:
         specifier: ^8.3.0
         version: 8.3.0(react@19.0.0)
@@ -48,6 +51,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.4
         version: 19.0.4(@types/react@19.0.12)
+      '@types/react-modal':
+        specifier: ^3.16.3
+        version: 3.16.3
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.2.3(jiti@1.21.7)(yaml@2.7.0))
@@ -749,6 +755,9 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
+  '@types/react-modal@3.16.3':
+    resolution: {integrity: sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==}
+
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
@@ -1109,6 +1118,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  exenv@1.2.2:
+    resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1585,6 +1597,15 @@ packages:
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
 
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
+  react-modal@3.16.3:
+    resolution: {integrity: sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
+      react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
+
   react-paginate@8.3.0:
     resolution: {integrity: sha512-TptZE37HPkT3R+7AszWA++LOTIsIHXcCSWMP9WW/abeF8sLpJzExFB/dVs7xbtqteJ5njF6kk+udTDC0AR3y5w==}
     peerDependencies:
@@ -1844,6 +1865,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2506,6 +2530,10 @@ snapshots:
     dependencies:
       '@types/react': 19.0.12
 
+  '@types/react-modal@3.16.3':
+    dependencies:
+      '@types/react': 19.0.12
+
   '@types/react-transition-group@4.4.12(@types/react@19.0.12)':
     dependencies:
       '@types/react': 19.0.12
@@ -2931,6 +2959,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  exenv@1.2.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -3350,6 +3380,17 @@ snapshots:
 
   react-is@19.1.0: {}
 
+  react-lifecycles-compat@3.0.4: {}
+
+  react-modal@3.16.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      exenv: 1.2.2
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-lifecycles-compat: 3.0.4
+      warning: 4.0.3
+
   react-paginate@8.3.0(react@19.0.0):
     dependencies:
       prop-types: 15.8.1
@@ -3598,6 +3639,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       yaml: 2.7.0
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   which@2.0.2:
     dependencies:

--- a/frontend/src/features/firmware/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware/ui/FirmwareRegister.tsx
@@ -31,12 +31,12 @@ export interface FirmwareRegisterFormProps {
  * @returns {JSX.Element} Rendered file upload placeholder component
  */
 const FileUploadPlaceHolder = ({
-  onclick,
+  onClick,
 }: {
-  onclick: () => void;
+  onClick: () => void;
 }): JSX.Element => (
   <div
-    onClick={onclick}
+    onClick={onClick}
     className="flex flex-col items-center justify-center w-full h-32 text-sm text-blue-900 border-2 border-dashed rounded-md cursor-pointer hover:border-blue-500 hover:text-blue-900"
   >
     <Upload size={24} className="mb-2 text-blue-900" />
@@ -238,7 +238,7 @@ export const FirmwareRegisterForm = ({
 
           {!formData.file ? (
             // If no file is selected, show the placeholder
-            <FileUploadPlaceHolder onclick={handleFileClick} />
+            <FileUploadPlaceHolder onClick={handleFileClick} />
           ) : (
             // If a file is selected, show the file preview
             <FilePreview file={formData.file} onRemove={handleRemoveFile} />

--- a/frontend/src/features/firmware/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware/ui/FirmwareRegister.tsx
@@ -1,0 +1,256 @@
+import { useRef, useState } from "react";
+import { Button } from "../../../shared/ui/Button";
+import { FileText, Upload } from "lucide-react";
+import { JSX } from "@emotion/react/jsx-runtime";
+
+/**
+ * Interface for FirmwareRegisterForm component props
+ * @interface
+ * @property {string} version - The firmware version
+ * @property {string} releaseNote - The release note for the firmware
+ * @property {File | null} file - The firmware file to be uploaded
+ */
+export interface FirmwareRegisterFormData {
+  version: string;
+  releaseNote: string;
+  file: File | null;
+}
+
+/**
+ * Interface for FirmwareRegisterForm component props
+ * @interface
+ * @property {Function} onClose - Optional callback function to be called when the form is closed
+ */
+export interface FirmwareRegisterFormProps {
+  onClose?: () => void;
+}
+
+/**
+ * File upload placeholder component
+ * @param {Function} onclick - Function to be called when the placeholder is clicked
+ * @returns {JSX.Element} Rendered file upload placeholder component
+ */
+const FileUploadPlaceHolder = ({
+  onclick,
+}: {
+  onclick: () => void;
+}): JSX.Element => (
+  <div
+    onClick={onclick}
+    className="flex flex-col items-center justify-center w-full h-32 text-sm text-blue-900 border-2 border-dashed rounded-md cursor-pointer hover:border-blue-500 hover:text-blue-900"
+  >
+    <Upload size={24} className="mb-2 text-blue-900" />
+    <p className="text-sm text-blue-900">펌웨어 파일을 선택하세요.</p>
+    <p className="text-xs text-neutral-500">
+      <span className="font-semibold">*.tft</span> 파일 (최대 50MB)
+    </p>
+  </div>
+);
+
+/**
+ * Selected file preview component
+ * @param {File} file - The selected file to be previewed
+ * @param {Function} onRemove - Handler function to remove the selected file
+ */
+const FilePreview = ({
+  file,
+  onRemove,
+}: {
+  file: File;
+  onRemove: () => void;
+}): JSX.Element => (
+  <div className="flex items-center justify-center w-full h-32 gap-2 px-2 text-sm border rounded-md cursor-pointer text-neutral-800 hover:border-blue-500 hover:text-blue-500">
+    <FileText size={20} className="text-blue-900" />
+    <p>{file.name}</p>
+    <button onClick={onRemove} className="text-red-500">
+      X
+    </button>
+  </div>
+);
+
+/**
+ * Firmware registration form component
+ * Provides a form for users to input firmware version, release notes, and upload a firmware file.
+ *
+ * @param {Function} onClose - Optional callback function to be called when the form is closed
+ * @returns {JSX.Element} Rendered firmware registration form component
+ */
+export const FirmwareRegisterForm = ({
+  onClose,
+}: FirmwareRegisterFormProps): JSX.Element => {
+  const [formData, setFormData] = useState<FirmwareRegisterFormData>({
+    version: "",
+    releaseNote: "",
+    file: null,
+  });
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * File input change handler
+   * Validates the file type and size before setting it in the form data.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event - The change event from the file input
+   */
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      const file = event.target.files[0];
+
+      if (!file.name.endsWith(".tft")) {
+        alert("*.tft 형식의 파일만 업로드 가능합니다.");
+        return;
+      }
+
+      if (file.size > 50 * 1024 * 1024) {
+        alert("파일 크기는 50MB를 초과할 수 없습니다.");
+        return;
+      }
+
+      setFormData((prev) => ({ ...prev, file: file }));
+    }
+  };
+
+  /**
+   * Opens the file selection dialog
+   */
+  const handleFileClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  /**
+   * Removes the selected file from the form data
+   */
+  const handleRemoveFile = () => {
+    setFormData((prev) => ({ ...prev, file: null }));
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  /**
+   * Resets form data and optionally closes the form
+   */
+  const handleReset = () => {
+    setFormData({
+      version: "",
+      releaseNote: "",
+      file: null,
+    });
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (onClose) onClose();
+  };
+
+  /**
+   * Validates the form data
+   * Checks if all required fields (version, release notes, file) are filled.
+   *
+   * @returns {boolean} - Returns true if the form is valid, otherwise false
+   */
+  const validateForm = (): boolean => {
+    // TODO: Add validation details if needed (e.g., validation message at the right side of the each label)
+    if (!formData.version) {
+      alert("펌웨어 버전을 입력하세요.");
+      return false;
+    }
+    if (!formData.releaseNote) {
+      alert("릴리즈 노트를 입력하세요.");
+      return false;
+    }
+    if (!formData.file) {
+      alert("펌웨어 파일을 선택하세요.");
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * Form submission handler
+   * Validates the form data and, if valid, makes an API call.
+   * Resets the form upon successful submission.
+   *
+   * @param event - The form submission event
+   */
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!validateForm()) return;
+
+    // TODO: Call API to register firmware
+    console.log("펌웨어 등록 요청");
+    console.log("버전:", formData.version);
+    console.log("릴리즈 노트:", formData.releaseNote);
+    console.log("파일:", formData.file);
+
+    // Reset form fields after submission
+    handleReset();
+  };
+
+  return (
+    <div>
+      <h3 className="mb-6 text-xl font-normal">펌웨어 등록</h3>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        {/* Version input field */}
+        <div className="flex flex-col gap-2">
+          <label htmlFor="firmwareVersion" className="text-sm text-neutral-600">
+            펌웨어 버전
+          </label>
+          <input
+            type="text"
+            id="firmwareVersion"
+            placeholder="예: 24.04.1"
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, version: e.target.value }))
+            }
+            className="px-2 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {/* Release Note input field */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="firmwareReleaseNote"
+            className="text-sm text-neutral-600"
+          >
+            릴리즈 노트
+          </label>
+          <textarea
+            id="firmwareReleaseNote"
+            rows={8}
+            placeholder="변경사항을 입력하세요."
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, releaseNote: e.target.value }))
+            }
+            className="px-2 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {/* Firmware file input field */}
+        <div className="flex flex-col gap-2">
+          <label htmlFor="firmwareFile" className="text-sm text-neutral-600">
+            펌웨어 파일
+          </label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            id="firmwareFile"
+            className="hidden"
+            accept=".tft"
+            onChange={handleFileChange}
+          />
+
+          {!formData.file ? (
+            // If no file is selected, show the placeholder
+            <FileUploadPlaceHolder onclick={handleFileClick} />
+          ) : (
+            // If a file is selected, show the file preview
+            <FilePreview file={formData.file} onRemove={handleRemoveFile} />
+          )}
+        </div>
+
+        {/* Submit button */}
+        <div className="flex items-center justify-end gap-2 mt-4">
+          <Button title="취소" variant="secondary" onClick={handleReset} />
+          <Button title="등록" variant="primary" type="submit" />
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/FirmwarePage.tsx
+++ b/frontend/src/pages/FirmwarePage.tsx
@@ -5,6 +5,10 @@ import { SearchBar } from "../shared/ui/SearchBar";
 import { MainTile } from "../widgets/layout/ui/MainTile";
 import { TitleTile } from "../widgets/layout/ui/TitleTile";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "../shared/ui/Button";
+import { useState } from "react";
+import ReactModal from "react-modal";
+import { FirmwareRegisterForm } from "../features/firmware/ui/FirmwareRegister";
 
 export const FirmwarePage = () => {
   const {
@@ -15,6 +19,8 @@ export const FirmwarePage = () => {
     handleSearch,
     handlePageChange,
   } = useFirmwareSearch();
+
+  const [fwRegisterModalOpen, setFwRegisterModalOpen] = useState(false);
 
   const handlePageClick = (event: { selected: number }) => {
     const newPage = event.selected + 1; // ReactPaginate uses zero-based index
@@ -40,7 +46,9 @@ export const FirmwarePage = () => {
             error={error}
           />
 
-          <div className="flex justify-center mt-6 text-neutral-500">
+          <div className="flex items-center justify-between mt-6 text-neutral-500">
+            {/* Empty div to align pagination & button to the right */}
+            <div></div>
             <ReactPaginate
               previousLabel={<ChevronLeft size={18} />}
               nextLabel={<ChevronRight size={18} />}
@@ -57,8 +65,26 @@ export const FirmwarePage = () => {
               breakLabel="..."
               breakClassName="px-2"
             />
+            <Button
+              title="펌웨어 등록"
+              onClick={() => {
+                setFwRegisterModalOpen(true);
+              }}
+            />
           </div>
         </MainTile>
+
+        <ReactModal
+          isOpen={fwRegisterModalOpen}
+          onRequestClose={() => setFwRegisterModalOpen(false)}
+          overlayClassName={"bg-black bg-opacity-50 fixed inset-0"}
+          appElement={document.getElementById("root") || undefined}
+          className={
+            "bg-white w-1/2 h-2/3 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 rounded-lg p-6"
+          }
+        >
+          <FirmwareRegisterForm onClose={() => setFwRegisterModalOpen(false)} />
+        </ReactModal>
       </div>
     </div>
   );


### PR DESCRIPTION
# Changelog
- 펌웨어를 등록할 수 있는 모달 창을 구현하였습니다.
  - 간편한 모달 창 구현을 위해 `react-modal` 라이브러리를 추가하였습니다.
  - 모달 창에서 `펌웨어 버전 정보`, `릴리즈 노트`, `TFT 파일`을 받을 수 있도록 구현하였습니다.

- TODO: 백엔드 구성 이후 API 연동 예정입니다.

# Testing
https://github.com/user-attachments/assets/d05aa6b9-873a-4536-a756-583c4002b922

# Ops Impact
N/A

# Version Compatibility
N/A