### PR TITLE
[FrontEnd] Firmware 등록 API 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.0.1",
     "axios": "^1.8.4",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.484.0",
     "pretendard": "^1.3.9",
     "react": "^19.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axios:
         specifier: ^1.8.4
         version: 1.8.4
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.484.0
         version: 0.484.0(react@19.0.0)
@@ -977,6 +980,9 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -1265,6 +1271,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1272,6 +1281,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1302,6 +1314,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1342,12 +1357,18 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1474,6 +1495,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1567,6 +1591,9 @@ packages:
   pretendard@1.3.9:
     resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1638,6 +1665,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -1673,6 +1703,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -1687,6 +1720,9 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1722,6 +1758,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2782,6 +2821,8 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-util-is@1.0.3: {}
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -3093,12 +3134,16 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   is-arrayish@0.2.1: {}
 
@@ -3121,6 +3166,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3150,6 +3197,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3158,6 +3212,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -3278,6 +3336,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3353,6 +3413,8 @@ snapshots:
 
   pretendard@1.3.9: {}
 
+  process-nextick-args@2.0.1: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3423,6 +3485,16 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -3473,6 +3545,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   scheduler@0.25.0: {}
 
   semver@6.3.1: {}
@@ -3480,6 +3554,8 @@ snapshots:
   semver@7.7.1: {}
 
   set-cookie-parser@2.7.1: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3508,6 +3584,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:

--- a/frontend/src/entities/firmware/api/firmwareApi.ts
+++ b/frontend/src/entities/firmware/api/firmwareApi.ts
@@ -145,16 +145,17 @@ export const firmwareApiService = {
       formData.append("release_note", releaseNote);
       formData.append("file", file);
 
-      // debug print
-      formData.forEach((value, key) => {
-        console.log(key, value);
-      });
+      const response = await apiClient.post(
+        "/api/firmware/register",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      );
 
-      return await apiClient.post("/api/firmware/register", formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      });
+      return response.status === 200;
     } catch (error) {
       console.error("Failed to register firmware:", error);
       return false;

--- a/frontend/src/entities/firmware/api/firmwareApi.ts
+++ b/frontend/src/entities/firmware/api/firmwareApi.ts
@@ -128,7 +128,7 @@ export const firmwareApiService = {
    * @param {string} version - The version of the firmware
    * @param {string} releaseNote - The release note for the firmware
    * @param {File} file - The firmware file to be uploaded
-   * @returns {Promise<void>} - A promise that resolves when the registration is complete
+   * @returns {Promise<boolean>} - A promise that resolves to true if registration is successful, false otherwise
    * @throws Will log error if API call fails
    * @example
    * // Register a new firmware

--- a/frontend/src/entities/firmware/api/firmwareApi.ts
+++ b/frontend/src/entities/firmware/api/firmwareApi.ts
@@ -121,4 +121,43 @@ export const firmwareApiService = {
       };
     }
   },
+
+  /**
+   * Registers a new firmware with the given version, release note, and file
+   * @async
+   * @param {string} version - The version of the firmware
+   * @param {string} releaseNote - The release note for the firmware
+   * @param {File} file - The firmware file to be uploaded
+   * @returns {Promise<void>} - A promise that resolves when the registration is complete
+   * @throws Will log error if API call fails
+   * @example
+   * // Register a new firmware
+   * await firmwareApiService.register('1.0', 'Initial release', myFirmwareFile);
+   */
+  register: async (
+    version: string,
+    releaseNote: string,
+    file: File
+  ): Promise<boolean> => {
+    try {
+      const formData = new FormData();
+      formData.append("version", version);
+      formData.append("release_note", releaseNote);
+      formData.append("file", file);
+
+      // debug print
+      formData.forEach((value, key) => {
+        console.log(key, value);
+      });
+
+      return await apiClient.post("/api/firmware/register", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
+    } catch (error) {
+      console.error("Failed to register firmware:", error);
+      return false;
+    }
+  },
 };

--- a/frontend/src/features/firmware/api/useFirmwareDetail.tsx
+++ b/frontend/src/features/firmware/api/useFirmwareDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Firmware } from "../../../entities/firmware/model/types";
-import { firmwareApiService } from "../../../entities/firmware/api/api";
+import { firmwareApiService } from "../../../entities/firmware/api/firmwareApi";
 
 /**
  * Interface for the return value of the useFirmwareDetail hook

--- a/frontend/src/features/firmware/api/useFirmwareSearch.tsx
+++ b/frontend/src/features/firmware/api/useFirmwareSearch.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Firmware } from "../../../entities/firmware/model/types";
-import { firmwareApiService } from "../../../entities/firmware/api/api";
+import { firmwareApiService } from "../../../entities/firmware/api/firmwareApi";
 import { PaginationMeta } from "../../../shared/api/types";
 
 /**

--- a/frontend/src/features/firmware/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware/ui/FirmwareRegister.tsx
@@ -184,9 +184,6 @@ export const FirmwareRegisterForm = ({
     } else {
       alert("펌웨어 등록에 실패했습니다.");
     }
-
-    // Reset form fields after submission
-    handleReset();
   };
 
   return (

--- a/frontend/src/features/firmware/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware/ui/FirmwareRegister.tsx
@@ -2,6 +2,8 @@ import { useRef, useState } from "react";
 import { Button } from "../../../shared/ui/Button";
 import { FileText, Upload } from "lucide-react";
 import { JSX } from "@emotion/react/jsx-runtime";
+import { firmwareApiService } from "../../../entities/firmware/api/firmwareApi";
+import { zipFile } from "../../../shared/api/zip";
 
 /**
  * Interface for FirmwareRegisterForm component props
@@ -139,45 +141,49 @@ export const FirmwareRegisterForm = ({
   };
 
   /**
-   * Validates the form data
-   * Checks if all required fields (version, release notes, file) are filled.
-   *
-   * @returns {boolean} - Returns true if the form is valid, otherwise false
-   */
-  const validateForm = (): boolean => {
-    // TODO: Add validation details if needed (e.g., validation message at the right side of the each label)
-    if (!formData.version) {
-      alert("펌웨어 버전을 입력하세요.");
-      return false;
-    }
-    if (!formData.releaseNote) {
-      alert("릴리즈 노트를 입력하세요.");
-      return false;
-    }
-    if (!formData.file) {
-      alert("펌웨어 파일을 선택하세요.");
-      return false;
-    }
-    return true;
-  };
-
-  /**
    * Form submission handler
    * Validates the form data and, if valid, makes an API call.
    * Resets the form upon successful submission.
    *
    * @param event - The form submission event
    */
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    if (!validateForm()) return;
+    // TODO: Implement toast message not alert for better UX
 
-    // TODO: Call API to register firmware
+    if (!formData.version) {
+      alert("펌웨어 버전을 입력하세요.");
+      return;
+    }
+    if (!formData.releaseNote) {
+      alert("릴리즈 노트를 입력하세요.");
+      return;
+    }
+    if (!formData.file) {
+      alert("펌웨어 파일을 선택하세요.");
+      return;
+    }
+
     console.log("펌웨어 등록 요청");
     console.log("버전:", formData.version);
     console.log("릴리즈 노트:", formData.releaseNote);
     console.log("파일:", formData.file);
+
+    const compressedFile = await zipFile(formData.file);
+
+    const success = await firmwareApiService.register(
+      formData.version,
+      formData.releaseNote,
+      compressedFile
+    );
+
+    if (success) {
+      alert("펌웨어 등록이 완료되었습니다.");
+      handleReset();
+    } else {
+      alert("펌웨어 등록에 실패했습니다.");
+    }
 
     // Reset form fields after submission
     handleReset();

--- a/frontend/src/shared/api/zip.ts
+++ b/frontend/src/shared/api/zip.ts
@@ -1,0 +1,27 @@
+import JSZip from "jszip";
+
+/**
+ * Compresses a file using JSZip and returns a new File object.
+ * @param {File} file - The file to be compressed.
+ * @returns {Promise<File>} - A promise that resolves to the compressed file.
+ */
+export const zipFile = async (file: File): Promise<File> => {
+  const zip = new JSZip();
+
+  zip.file(file.name, file);
+
+  const zipContent = await zip.generateAsync({
+    type: "blob",
+    compression: "DEFLATE",
+    compressionOptions: {
+      level: 9,
+    },
+  });
+
+  const compressedFile = new File([zipContent], `${file.name}.zip`, {
+    type: "application/zip",
+    lastModified: Date.now(),
+  });
+
+  return compressedFile;
+};


### PR DESCRIPTION
# Changelog
- 펌웨어 등록 POST 요청을 보내는 `firmwareApiService.register()`를 추가하였습니다.
- 펌웨어 등록 POST 요청의 구조는 다음과 같습니다.
```
# multipart/form-data
{
  "version": "24.04.01",
  "releaseNote": "This is Release Note",
  "file": {compressed file}
}
```

# Testing
<img width="533" alt="image" src="https://github.com/user-attachments/assets/4efed883-f0d9-45a3-b3ca-57ad8c8a7a9d" />

+ 최소 API 요청에 대해서는 Unit Test를 추가할 예정입니다. 다음 PR (ㅎㅎ)

# Ops Impact
N/A

# Version Compatibility
N/A