### PR TITLE
[Terraform] Terraform 초기 설정

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*.plan
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.96.0"
+  hashes = [
+    "h1:a/VEUu6BGQSPlUAzbN+zqaDCdi0QGh/VzBgo2gCran0=",
+    "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
+    "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
+    "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",
+    "zh:68f2328e7f3e7666835d6815b39b46b08954a91204f82a6f648c928a0b09a744",
+    "zh:6a4170e7e2764df2968d1df65efebda55273dfc36dc6741207afb5e4b7e85448",
+    "zh:73f2a15bee21f7c92a071e2520216d0a40041aca52c0f6682e540da8ffcfada4",
+    "zh:9843d6973aedfd4cbaafd7110420d0c4c1d7ef4a2eeff508294c3adcc3613145",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d1abd6be717c42f2a6257ee227d3e9548c31f01c976ed7b32b2745a63659a67",
+    "zh:a70d642e323021d54a92f0daa81d096cb5067cb99ce116047a42eb1cb1d579a0",
+    "zh:b9a2b293208d5a0449275fae463319e0998c841e0bcd4014594a49ba54bb70d6",
+    "zh:ce0b0eb7ac24ff58c20efcb526c3f792a95be3617c795b45bbeea9f302903ae7",
+    "zh:dbbf98b3cd8003833c472bdb89321c17a9bbdc1b785e7e3d75f8af924ee5a0e4",
+    "zh:df86cf9311a4be8bb4a251196650653f97e01fbf5fe72deecc8f28a35a5352ae",
+    "zh:f92992881afd9339f3e539fcd90cfc1e9ed1356b5e760bbcc804314c3cd6837f",
+  ]
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+terraform {
+  backend "s3" {
+    bucket       = "iot-cloud-ota-tf-state-bucket"
+    key          = "terraform/state"
+    region       = "ap-northeast-2"
+    use_lockfile = true
+  }
+}

--- a/terraform/remote-state.tf
+++ b/terraform/remote-state.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "remote_state" {
+  bucket = "iot-cloud-ota-tf-state-bucket"
+
+  tags = {
+    "Name"        = "iot-cloud-ota-tf-state-bucket"
+    "Description" = "S3 bucket for storing Terraform remote state"
+  }
+}


### PR DESCRIPTION
# Changelog
- `aws` provider를 사용하여 AWS 리소스를 원격으로 컨트롤 할 수 있도록 하였습니다.
- `iot-cloud-ota-tf-state-bucket` S3 버켓을 이용해 Terraform State를 원격으로 관리하도록 하였습니다.
- Terraform 프로젝트에 필요한 `.gitignore`를 추가하였습니다.

# Testing
- State를 저장하는 S3 버켓
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/49744fa5-2b4a-45ea-9bb8-3dfd45dd49b2" />

# Ops Impact
N/A

# Version Compatibility
N/A