### PR TITLE
[Terraform] CloudFront Signed URL 생성을 위한 RSA 키 페어 추가

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.97.0"
   hashes = [

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,25 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.0"
-  hashes = [
-    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
-    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
-    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
-    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
-    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
-    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
-    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
-    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
-    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
-    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
-    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.97.0"
   hashes = [

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -36,6 +36,7 @@ resource "aws_cloudfront_distribution" "firmware_distribution" {
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = local.s3_origin_id
     viewer_protocol_policy = "redirect-to-https"
+    trusted_key_groups     = [aws_cloudfront_key_group.signing_key_group.id]
 
     cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" # CachingOptimized
     origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" # CORS-S3Origin
@@ -77,4 +78,19 @@ resource "aws_s3_bucket_policy" "allow_cloudfront_access" {
       }
     ]
   })
+}
+
+data "aws_secretsmanager_secret_version" "public_signing_key" {
+  secret_id = "cloudfront/signed_url/public_key"
+}
+
+resource "aws_cloudfront_public_key" "signing_key" {
+  name        = "cloudfront-signing-key"
+  comment     = "Public key for CloudFront signed URLs"
+  encoded_key = data.aws_secretsmanager_secret_version.public_signing_key.secret_string
+}
+
+resource "aws_cloudfront_key_group" "signing_key_group" {
+  name  = "cloudfront-signing-key-group"
+  items = [aws_cloudfront_public_key.signing_key.id]
 }

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -84,6 +84,10 @@ data "aws_secretsmanager_secret_version" "public_signing_key" {
   secret_id = "cloudfront/signed_url/public_key"
 }
 
+data "aws_secretsmanager_secret_version" "private_signing_key" {
+  secret_id = "cloudfront/signed_url/private_key"
+}
+
 resource "aws_cloudfront_public_key" "signing_key" {
   name        = "cloudfront-signing-key"
   comment     = "Public key for CloudFront signed URLs"

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -80,12 +80,20 @@ resource "aws_s3_bucket_policy" "allow_cloudfront_access" {
   })
 }
 
+data "aws_secretsmanager_secret" "public_signing_key" {
+  name = "cloudfront/signed_url/public_key"
+}
+
 data "aws_secretsmanager_secret_version" "public_signing_key" {
-  secret_id = "cloudfront/signed_url/public_key"
+  secret_id = data.aws_secretsmanager_secret.public_signing_key.id
+}
+
+data "aws_secretsmanager_secret" "private_signing_key" {
+  name = "cloudfront/signed_url/private_key"
 }
 
 data "aws_secretsmanager_secret_version" "private_signing_key" {
-  secret_id = "cloudfront/signed_url/private_key"
+  secret_id = data.aws_secretsmanager_secret.private_signing_key.id
 }
 
 resource "aws_cloudfront_public_key" "signing_key" {


### PR DESCRIPTION
# Changelog
- CloudFront Signed URL 생성 시 필요한 RSA 키 페어를 AWS Secrets Manager에 추가하였습니다.
- 키 페어 중 Public Key를 CloudFront Public Key로 등록하였습니다.

# Testing
- CloudFront 키 생성 결과
<img width="1311" alt="Screenshot 2025-05-16 at 2 59 15 PM" src="https://github.com/user-attachments/assets/3ab8064c-53fd-43e3-b8fb-1218df9d784d" />

- 테스트용 CloudFront Pre-signed URL 생성 람다 함수
```
import os
import boto3
import datetime
import botocore.signers
import rsa
import json

# Environment variables
CLOUDFRONT_SECRET_NAME = os.environ.get('CLOUDFRONT_SECRET_NAME')
CLOUDFRONT_DOMAIN = os.environ.get('CLOUDFRONT_DOMAIN')
CLOUDFRONT_KEY_ID = os.environ.get('CLOUDFRONT_KEY_ID')


def get_secret():
    """Fetches the RSA private key from AWS Secrets Manager."""
    client = boto3.client('secretsmanager')
    response = client.get_secret_value(SecretId=CLOUDFRONT_SECRET_NAME)
    secret = response['SecretString']
    return secret


def rsa_signer(message):
    """Signs the message using the RSA private key."""
    private_key_data = get_secret()
    private_key = rsa.PrivateKey.load_pkcs1(private_key_data.encode('utf-8'))
    return rsa.sign(message, private_key, 'SHA-1')


def lambda_handler(event, context):
    """Lambda function to generate a signed URL for CloudFront."""
    # Extract the file name and expiration time from the event
    file_name = event.get('file_name')
    expire_minutes = event.get('expire_minutes', 10)

    if not file_name:
        return {
            "statusCode": 400,
            "body": json.dumps({"error": "file_name is required"})
        }

    url = f"https://{CLOUDFRONT_DOMAIN}/{file_name}"

    # Set the expiration time for the signed URL
    expire_date = datetime.datetime.now(
        tz=datetime.timezone.utc) + datetime.timedelta(minutes=expire_minutes)

    # Create a CloudFront signer
    cloudfront_signer = botocore.signers.CloudFrontSigner(
        CLOUDFRONT_KEY_ID, rsa_signer)

    # Generate the signed URL
    signed_url = cloudfront_signer.generate_presigned_url(
        url, date_less_than=expire_date)

    return {
        "statusCode": 200,
        "body": json.dumps({"cloudfront_signed_url": signed_url})
    }
```

```
module "test_signed_url" {
  source        = "./modules/lambda"
  function_name = "test_signed_url"
  description   = "Lambda function to generate signed URLs for CloudFront"
  handler       = "main.lambda_handler"
  runtime       = "python3.10"
  timeout       = 30
  memory_size   = 128
  source_path   = "./src/test_signed_url"
  environment_variables = {
    CLOUDFRONT_SECRET_NAME = data.aws_secretsmanager_secret.private_signing_key.name
    CLOUDFRONT_DOMAIN      = aws_cloudfront_distribution.firmware_distribution.domain_name,
    CLOUDFRONT_KEY_ID      = aws_cloudfront_public_key.signing_key.id,
  }
  policy_statements = [
    {
      effect    = "Allow"
      actions   = ["s3:GetObject"]
      resources = ["arn:aws:s3:::${aws_s3_bucket.firmware_bucket.id}"]
    },
    {
      effect    = "Allow"
      actions   = ["secretsmanager:GetSecretValue"]
      resources = [data.aws_secretsmanager_secret.private_signing_key.arn]
    }
  ]
}
```
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/3e5c0b3d-4d4a-4c75-abbf-5720ed5cd2d2" />

# Ops Impact
N/A

# Version Compatibility
N/A