### PR TITLE
[FrontEnd] 레이아웃 및 사이드바 컴포넌트 개선 (#46)

### DIFF
--- a/frontend/src/widgets/layout/ui/Layout.tsx
+++ b/frontend/src/widgets/layout/ui/Layout.tsx
@@ -1,11 +1,18 @@
 import { Outlet } from "react-router";
 import { SideBar } from "../../sidebar/ui/Sidebar";
+import { Navbar } from "../../sidebar/ui/Navbar";
+import { useMediaQuery } from "@mui/material";
 
 export const Layout = () => {
+  const isMobile = useMediaQuery("(max-width: 1024px)");
+
   return (
     <div className="flex h-screen">
+      <Navbar />
       <SideBar />
-      <main className="flex-1 p-8 overflow-y-auto bg-slate-200">
+      {/* mt-12 is for mobile view to avoid overlap with navbar */}
+      {/* ml-60 is for desktop view to avoid overlap with sidebar */}
+      <main className={`flex-1 p-8 overflow-y-auto bg-slate-200 ${isMobile ? 'mt-12' : 'ml-60'}`}>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/widgets/sidebar/ui/Navbar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Navbar.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { useMediaQuery } from "@mui/material";
+import { Menu } from "lucide-react";
+import { NavigationMenu } from "./NavigationMenu";
+
+export const Navbar = () => {
+  const isMobile = useMediaQuery("(max-width: 1024px)"); // Hook for mobile view
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  if (!isMobile) { // Hide navbar on desktop
+    return null;
+  }
+
+  return (
+    <nav className="fixed top-0 left-0 right-0 bg-slate-900 z-50">
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            className="text-gray-300 hover:text-white"
+          >
+            <Menu size={24} />
+          </button>
+          <p className="text-gray-300">Junwoo Park</p>
+        </div>
+      </div>
+      
+      {/* 모바일 메뉴 */}
+      {isMenuOpen && (
+        <div className="bg-slate-800 py-4">
+          <NavigationMenu onMenuClick={() => setIsMenuOpen(false)} />
+        </div>
+      )}
+    </nav>
+  );
+}; 

--- a/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
@@ -2,17 +2,21 @@ import { Link, useLocation } from "react-router";
 import { useNavigation } from "../model/useNavigation";
 import { NavigationItem } from "./NavigationItem";
 
-export const NavigationMenu = () => {
+interface NavigationMenuProps {
+  onMenuClick?: () => void;
+}
+
+export const NavigationMenu = ({ onMenuClick }: NavigationMenuProps) => {
   const { navigationItems } = useNavigation();
 
-  // 현재 경로 계산, NavigationItem이 Active한지 판별하는데 사용
+  // Calculate current path, used to determine if NavigationItem is active
   const location = useLocation();
   const currentPath = location.pathname;
 
   return (
     <div className="flex flex-col items-start gap-12 pl-16">
       {navigationItems.map((item) => (
-        <Link to={item.path} key={item.id}>
+        <Link to={item.path} key={item.id} onClick={onMenuClick}>
           <NavigationItem
             key={item.id}
             icon={item.icon}

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -1,9 +1,16 @@
 import Divider from "@mui/material/Divider";
 import { NavigationMenu } from "./NavigationMenu";
+import { useMediaQuery } from "@mui/material";
 
 export const SideBar = () => {
+  const isMobile = useMediaQuery("(max-width: 1024px)"); // Hook for mobile view
+
+  if (isMobile) {
+    return null; // Hide sidebar on mobile
+  }
+
   return (
-    <div className="flex flex-col h-full bg-slate-900 w-60">
+    <div className="flex flex-col h-full bg-slate-900 w-60 fixed left-0 top-0">
       <div className="flex flex-col items-center justify-center mt-8">
         <div className="flex items-center justify-center w-32 h-32 rounded-full bg-white/50">
           {/* TODO: Add User Avatar */}


### PR DESCRIPTION
* 모바일 뷰에 맞춰 Navbar 추가 및 사이드바 숨김 기능 구현
* 레이아웃에서 모바일 및 데스크탑 뷰에 따른 스타일 조정

# Changelog

* 모바일 뷰에 맞춰 Navbar 추가 및 Sidebar 숨김 기능 구현
* 레이아웃에서 모바일 및 데스크탑 뷰에 따른 스타일 조정
* 미디어쿼리는 1024px을 기준으로 작동하여 새로 테블릿에서는 Navbar가 작동하고, 그 이후로는 Sidebar가 렌더되어 작동함
* Navbar의 경우 탭을 옮길 경우 NavigationMenu를 자동으로 닫도록 이벤트리스너 추가

# Testing

화면의 너비를 조정하여 테스트합니다. 1024px을 기준으로 작동합니다.
Navbar가 노출될 경우, 클릭하여 메뉴들이 잘 노출되는지 확인합니다.

Sidebar 작동화면
![image](https://github.com/user-attachments/assets/f58b0a7a-71f5-45ee-8e28-091ad746da2a)

Navbar 작동화면
![image](https://github.com/user-attachments/assets/1a0faa52-2c03-4af5-bbb9-47f882333965)

Navbar 메뉴를 연 화면
![image](https://github.com/user-attachments/assets/456caddf-dddc-470c-8633-4b2515851557)

# Ops Impact

N/A

# Version Compatibility

N/A
