### PR TITLE
[Terraform] RDS 인스턴스 생성

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,9 @@
+module "rds" {
+  source           = "./modules/rds"
+  db_name          = "applicationdb"
+  db_identifier    = "iot-cloud-ota"
+  db_username      = data.aws_ssm_parameter.db_username.value
+  db_password      = data.aws_ssm_parameter.db_password.value
+  vpc_id           = aws_default_vpc.default.id
+  web_sg_id        = aws_security_group.web_sg.id
+}

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -1,0 +1,46 @@
+# aws ssm parameter store에서 값 가져옴
+data "aws_ssm_parameter" "db_username" {
+  name = "/myapp/config/db_username"
+}
+
+output "db_username_value" {
+  value = data.aws_ssm_parameter.db_username.value
+  sensitive = true
+}
+
+data "aws_ssm_parameter" "account_id" {
+  name = "/myapp/config/account_id"
+}
+
+output "account_id_value" {
+  value = data.aws_ssm_parameter.account_id.value
+  sensitive = true
+}
+
+data "aws_ssm_parameter" "db_password" {
+  name = "/myapp/config/db_password"
+  with_decryption = true
+}
+
+output "db_password_value" {
+  value = data.aws_ssm_parameter.db_password.value
+  sensitive = true
+}
+
+data "aws_ssm_parameter" "db_host" {
+  name = "/myapp/config/db_host"
+}
+
+output "db_host_value" {
+  value = "/myapp/config/db_host"
+  sensitive = true
+}
+
+data "aws_ssm_parameter" "s3_bucketname" {
+  name = "/myapp/config/s3_bucketname"
+}
+
+output "s3_bucketname_value" {
+  value = "/myapp/config/s3_bucketname"
+  sensitive = true
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,29 @@
+resource "aws_default_vpc" "default" {
+  tags = {
+    Name = "default vpc"
+  }
+}
+
+resource "aws_security_group" "web_sg" {
+  name        = "webserver security group"
+  description = "Enable HTTP access on port 80"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "webserver security group"
+  }
+}


### PR DESCRIPTION
# Changelog

- RDS 모듈을 통해 RDS 인스턴스를 생성했습니다.
- `vpc.tf`에 기본 VPC 및 Security Group을 추가하였습니다.
- `db_username` `db_password` `account_id`를 SSM Parameter Store에 저장하여 사용하였습니다.

# Testing

- AWS Console에서 RDS 인스턴스 정상 생성 확인
<img width="929" alt="스크린샷 2025-05-26 오후 4 03 05" src="https://github.com/user-attachments/assets/2d696fc2-f5dc-4d06-be38-64dcdc6269bb" />

- DBeaver로 데이터베이스 연결 시도 → 접속 성공 확인
<img width="138" alt="스크린샷 2025-05-26 오후 4 03 54" src="https://github.com/user-attachments/assets/a70552dc-da21-4fc4-b278-ac804c79cc30" />

# Ops Impact

N/A

# Version Compatibility

N/A
