### PR TITLE
[Terraform] RDS와 Lambda를 위한 Security Groups 생성

### DIFF
--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "mysql_sg" {
+  name        = "iot-cloud-ota-mysql-sg"
+  description = "Security group for MySQL access"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda_sg.id]
+    description     = "MySQL access from public subnets"
+  }
+
+}
+
+resource "aws_security_group" "lambda_sg" {
+  name        = "iot-cloud-ota-lambda-sg"
+  description = "Security group for Lambda functions"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-lambda-sg"
+    Description = "Security group for Lambda functions in iot-cloud-ota"
+  }
+}


### PR DESCRIPTION
# Changelog
- RDS와 Lambda 전용 Security Groups를 생성하였습니다.
- Lambda는 RDS에 접근 가능하도록 설정하였습니다.

# Testing
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_security_group.lambda_sg will be created
  + resource "aws_security_group" "lambda_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for Lambda functions"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "Allow all outbound traffic"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "iot-cloud-ota-lambda-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Description" = "Security group for Lambda functions in iot-cloud-ota"
          + "Name"        = "iot-cloud-ota-lambda-sg"
        }
      + tags_all               = {
          + "Description" = "Security group for Lambda functions in iot-cloud-ota"
          + "Name"        = "iot-cloud-ota-lambda-sg"
        }
      + vpc_id                 = "vpc-02a4db8b6f0c133b4"
    }

  # aws_security_group.mysql_sg will be created
  + resource "aws_security_group" "mysql_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for MySQL access"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = []
              + description      = "MySQL access from public subnets"
              + from_port        = 3306
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = (known after apply)
              + self             = false
              + to_port          = 3306
            },
        ]
      + name                   = "iot-cloud-ota-mysql-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags_all               = (known after apply)
      + vpc_id                 = "vpc-02a4db8b6f0c133b4"
    }

Plan: 2 to add, 0 to change, 0 to destroy
```

# Ops Impact
N/A

# Version Compatibility
N/A