### PR TITLE
[Terraform] EMQX 세팅

### DIFF
--- a/terraform/emqx.tf
+++ b/terraform/emqx.tf
@@ -1,0 +1,23 @@
+# NOTE: EMQX는 ELB를 사용하여 클러스터를 구성하고 부하 분산을 하는 것이 좋습니다.
+# 하지만 현재 개발 환경에서는 비용적인 한계로 단일 인스턴스로 EMQX를 배포합니다.
+# 이후 프로덕션 환경에서는 ELB를 사용하여 EMQX 클러스터를 구성하는 것을 고려합니다.
+
+resource "aws_instance" "emqx" {
+  ami                    = "ami-0c9c942bd7bf113a2" # Ubuntu 22.04 LTS
+  instance_type          = "t3.micro"
+  vpc_security_group_ids = [aws_security_group.emqx_sg.id]
+  subnet_id              = aws_subnet.public_a.id
+
+  user_data = <<-EOF
+    #!/bin/bash
+    sudo apt-get update && \
+    curl -s https://assets.emqx.com/scripts/install-emqx-deb.sh | sudo bash && \
+    sudo apt-get install -y emqx && \
+    sudo systemctl start emqx
+  EOF
+
+  tags = {
+    Name        = "iot-cloud-ota-emqx"
+    Description = "EMQX broker for iot-cloud-ota"
+  }
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -77,3 +77,37 @@ resource "aws_security_group" "bastion_sg" {
     Description = "Security group for Bastion host in iot-cloud-ota"
   }
 }
+
+resource "aws_security_group" "emqx_sg" {
+  name        = "iot-cloud-ota-emqx-sg"
+  description = "Security group for EMQX broker"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 1883 # MQTT without TLS
+    to_port     = 1883
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8883 # MQTT with TLS
+    to_port     = 8883
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 18083 # EMQX Dashboard
+    to_port     = 18083
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
# Changelog
- EC2 인스턴스에 EMQX를 세팅하였습니다.
- user_data를 통해 인스턴트가 실행될 때 EMQX를 설치하고 실행합니다.
- 원활한 개발을 위해 외부에서 MQTT 메시지를 보내고 구독할 수 있도록 Security Group을 구성하였습니다.

# Testing
- MQTT 메시지 publish / subscribe 테스트
```
# mqtt_publish.py
import paho.mqtt.client as mqtt
from paho.mqtt.enums import CallbackAPIVersion

broker_address = "3.38.104.113"
topic = "test/topic"

client = mqtt.Client(CallbackAPIVersion.VERSION2)
client.connect(broker_address, 1883, 60)
client.publish(topic, "Hello, MQTT!")  # 메시지 발행
print("Message published to topic:", topic)
client.disconnect()

# mqtt_subscribe.py
import paho.mqtt.client as mqtt
from paho.mqtt.enums import CallbackAPIVersion

broker_address = "3.38.104.113"
topic = "test/topic"


def on_message(client, userdata, message):
    print(f"Received message: {message.payload.decode()}")


client = mqtt.Client(CallbackAPIVersion.VERSION2)
client.connect(broker_address, 1883, 60)
client.subscribe(topic)
client.on_message = on_message
client.loop_forever()
```
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/8351b1d1-30d3-496d-92fa-ea1c514d0eba" />

# Ops Impact
N/A

# Version Compatibility
N/A