### PR TITLE
[Backend] 펌웨어 메타데이터 등록 API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/IotCloudOtaApplication.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/IotCloudOtaApplication.java
@@ -2,12 +2,14 @@ package com.coffee_is_essential.iot_cloud_ota;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class IotCloudOtaApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(IotCloudOtaApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(IotCloudOtaApplication.class, args);
+    }
 
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -1,7 +1,10 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataRequestDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.PresignedUrlRequestDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.PresignedUrlResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.service.FirmwareMetadataService;
 import com.coffee_is_essential.iot_cloud_ota.service.S3Service;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,18 +12,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 펌웨어 관련 요청을 처리하는 REST 컨트롤러입니다.
+ */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/firmwares")
 public class FirmwareController {
     private final S3Service s3Service;
+    private final FirmwareMetadataService firmwareMetadataService;
 
     /**
-     * Presigned URL 발급을 위한 엔드포인트입니다.
-     * 클라이언트는 이 URL을 통해 인증 없이 S3에 펌웨어 파일을 업로드할 수 있습니다.
+     * Presigned URL을 발급하여 클라이언트가 인증 없이 S3에 펌웨어 파일을 업로드할 수 있도록 합니다.
      *
-     * @param requestDto 업로드할 버전 및 파일명을 담은 요청 DTO
-     * @return 업로드 가능한 Presigned URL을 담은 응답 DTO
+     * @param requestDto 업로드할 버전 및 파일명을 포함한 요청 DTO
+     * @return 업로드 가능한 Presigned URL을 포함한 응답 DTO
      */
     @PostMapping("/presigned_url")
     public ResponseEntity<PresignedUrlResponseDto> issuePresignedUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
@@ -28,5 +34,18 @@ public class FirmwareController {
         PresignedUrlResponseDto responseDto = new PresignedUrlResponseDto(url);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    /**
+     * 펌웨어 메타데이터를 저장합니다.
+     *
+     * @param requestDto 저장할 펌웨어 메타데이터를 포함한 요청 DTO
+     * @return 저장된 펌웨어 메타데이터 정보가 포함된 응답 DTO
+     */
+    @PostMapping("/metadata")
+    public ResponseEntity<FirmwareMetadataResponseDto> saveFirmwareMetadata(@Valid @RequestBody FirmwareMetadataRequestDto requestDto) {
+        FirmwareMetadataResponseDto responseDto = firmwareMetadataService.saveFirmwareMetadata(requestDto);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/ErrorResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/ErrorResponseDto.java
@@ -3,7 +3,7 @@ package com.coffee_is_essential.iot_cloud_ota.dto;
 import java.util.Map;
 
 /**
- * 에러메시지를 반환하는 Dto입니다.
+ * 에러메시지를 반환하는 DTO 입니다.
  *
  * @param errors errors 필드명과 에러 메시지를 담은 Map
  */

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataRequestDto.java
@@ -1,0 +1,20 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 펌웨어 메타데이터 등록 요청을 위한 DTO 입니다.
+ *
+ * @param version     펌웨어 버전
+ * @param fileName    펌웨어 파일 이름
+ * @param releaseNote 릴리즈 노트
+ */
+public record FirmwareMetadataRequestDto(
+        @NotBlank(message = "버전은 비어있을 수 없습니다.")
+        String version,
+        @NotBlank(message = "파일명은 비어있을 수 없습니다.")
+        String fileName,
+        @NotBlank(message = "릴리즈 노트는 비어있을 수 없습니다.")
+        String releaseNote
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataResponseDto.java
@@ -1,0 +1,42 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
+
+import java.time.LocalDateTime;
+
+/**
+ * 펌웨어 메타데이터 응답을 위한 DTO 입니다.
+ *
+ * @param id          펌웨어 메타데이터의 고유 ID
+ * @param version     펌웨어 버전
+ * @param fileName    펌웨어 파일 이름
+ * @param releaseNote 릴리즈 노트
+ * @param createdAt   생성 시각
+ * @param modifiedAt  마지막 수정 시각
+ */
+public record FirmwareMetadataResponseDto(
+        Long id,
+        String version,
+        String fileName,
+        String releaseNote,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+
+    /**
+     * 엔티티로부터 response DTO 객체를 생성합니다.
+     *
+     * @param firmwareMetadata 변환할 펌웨어 메타데이터 엔티티
+     * @return 변환된 response DTO
+     */
+    public static FirmwareMetadataResponseDto from(FirmwareMetadata firmwareMetadata) {
+        return new FirmwareMetadataResponseDto(
+                firmwareMetadata.getId(),
+                firmwareMetadata.getVersion(),
+                firmwareMetadata.getFileName(),
+                firmwareMetadata.getReleaseNote(),
+                firmwareMetadata.getCreatedAt(),
+                firmwareMetadata.getModifiedAt()
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlRequestDto.java
@@ -3,7 +3,7 @@ package com.coffee_is_essential.iot_cloud_ota.dto;
 import jakarta.validation.constraints.NotBlank;
 
 /**
- * S3 Presigned URL 요청 DTO입니다.
+ * S3 Presigned URL 요청 DTO 입니다.
  * 클라이언트가 업로드할 펌웨어 파일의 버전과 파일명을 전달합니다.
  *
  * @param version  업로드할 펌웨어의 버전 (예: "v1.0.0")

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlResponseDto.java
@@ -1,7 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.dto;
 
 /**
- * S3 Presigned URL 응답 DTO입니다.
+ * S3 Presigned URL 응답 DTO 입니다.
  * 클라이언트가 해당 URL을 사용하여 S3에 직접 업로드할 수 있습니다.
  *
  * @param url S3에 PUT 요청을 보낼 수 있는 Presigned URL

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/BaseEntity.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.coffee_is_essential.iot_cloud_ota.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 엔티티 생성 및 수정 시간을 자동으로 관리하는 기본 엔티티 클래스입니다.
+ * 모든 엔티티에서 공통적으로 상속받아 사용합니다.
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
@@ -1,0 +1,34 @@
+package com.coffee_is_essential.iot_cloud_ota.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 펌웨어 메타데이터 정보를 저장하는 엔티티 클래스입니다.
+ * 버전, 파일명, 릴리즈 노트의 정보를 저장합니다.
+ */
+@Getter
+@Entity
+@Table(name = "firmware_metadata")
+@NoArgsConstructor
+public class FirmwareMetadata extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String version;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String releaseNote;
+
+    public FirmwareMetadata(String version, String fileName, String releaseNote) {
+        this.version = version;
+        this.fileName = fileName;
+        this.releaseNote = releaseNote;
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -1,0 +1,7 @@
+package com.coffee_is_essential.iot_cloud_ota.repository;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMetadata, Long> {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -1,0 +1,26 @@
+package com.coffee_is_essential.iot_cloud_ota.service;
+
+import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataRequestDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
+import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FirmwareMetadataService {
+    private final FirmwareMetadataJpaRepository firmwareMetadataJpaRepository;
+
+    public FirmwareMetadataResponseDto saveFirmwareMetadata(FirmwareMetadataRequestDto requestDto) {
+        FirmwareMetadata firmwareMetadata = new FirmwareMetadata(
+                requestDto.version(),
+                requestDto.fileName(),
+                requestDto.releaseNote()
+        );
+
+        FirmwareMetadata savedFirmwareMetadata = firmwareMetadataJpaRepository.save(firmwareMetadata);
+
+        return FirmwareMetadataResponseDto.from(savedFirmwareMetadata);
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -7,11 +7,20 @@ import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepos
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 펌웨어 메타데이터의 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
 @Service
 @RequiredArgsConstructor
 public class FirmwareMetadataService {
     private final FirmwareMetadataJpaRepository firmwareMetadataJpaRepository;
 
+    /**
+     * 펌웨어 메타데이터를 저장하고, 저장된 결과를 응답 DTO로 반환합니다.
+     *
+     * @param requestDto 저장할 펌웨어 메타데이터 요청 DTO
+     * @return 저장된 펌웨어 정보를 담은 응답 DTO
+     */
     public FirmwareMetadataResponseDto saveFirmwareMetadata(FirmwareMetadataRequestDto requestDto) {
         FirmwareMetadata firmwareMetadata = new FirmwareMetadata(
                 requestDto.version(),

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=iot-cloud-ota
 spring.config.import=optional:file:.env[.properties]
 
 # JPA
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
# Changelog

- 펌웨어 메타데이터 저장 `POST` `API /api/firmwares/metadata` 추가

# Testing

- Postman으로 메타데이터 저장 API 호출 테스트를 진행함

<img width="458" alt="image" src="https://github.com/user-attachments/assets/1eb642bd-780a-492f-9f02-59a89da1f929" />

- 정상적으로 DB에 저장 확인

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/11435a16-126e-4274-89dc-b1a6454a959a" />

# Ops Impact

N/A

# Version Compatibility

N/A