### PR TITLE
[Backend] 페이징 처리된 펌웨어 메타데이터 조회 기능 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
@@ -1,0 +1,34 @@
+package com.coffee_is_essential.iot_cloud_ota.component;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
+import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * 애플리케이션 시작 시 테스트용 펌웨어 메타데이터를 DB에 삽입하는 컴포넌트입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MockDataInitializer implements CommandLineRunner {
+    private final FirmwareMetadataJpaRepository firmwareMetadataJpaRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.01", "24.04.01.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.02", "24.04.02.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.03", "24.04.03.ino", "연두해요 연두 광고를 업로드하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.04", "24.04.04.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.05", "24.04.05.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.06", "24.04.06.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.07", "24.04.07.ino", "연두해요 연두 광고를 업로드하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.08", "24.04.08.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.09", "24.04.09.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.10", "24.04.10.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.11", "24.04.11.ino", "연두해요 연두 광고를 업로드하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.12", "24.04.12.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -1,9 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
-import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataRequestDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.PresignedUrlRequestDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.PresignedUrlResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.*;
 import com.coffee_is_essential.iot_cloud_ota.service.FirmwareMetadataService;
 import com.coffee_is_essential.iot_cloud_ota.service.S3Service;
 import jakarta.validation.Valid;
@@ -47,5 +44,14 @@ public class FirmwareController {
         FirmwareMetadataResponseDto responseDto = firmwareMetadataService.saveFirmwareMetadata(requestDto);
 
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/metadata")
+    public ResponseEntity<PaginatedFirmwareMetadataResponseDto> findAll(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+
+        return null;
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -46,12 +46,20 @@ public class FirmwareController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    /**
+     * 펌웨어 메타데이터 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param page  조회할 페이지 번호 (기본값: 1)
+     * @param limit 페이지당 항목 수 (기본값: 10)
+     * @return 페이징된 펌웨어 메타데이터 목록과 페이지 정보가 포함된 응답 DTO
+     */
     @GetMapping("/metadata")
-    public ResponseEntity<PaginatedFirmwareMetadataResponseDto> findAll(
+    public ResponseEntity<FirmwareMetadataWithPageResponseDto> findAllWithPagination(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int limit
     ) {
+        FirmwareMetadataWithPageResponseDto responseDto = firmwareMetadataService.findAllWithPagination(page, limit);
 
-        return null;
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataWithPageResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataWithPageResponseDto.java
@@ -5,11 +5,11 @@ import java.util.List;
 /**
  * 페이징된 펌웨어 메타데이터 목록과 페이지 정보가 포함된 응답 DTO 입니다.
  *
- * @param content               조회된 펌웨어 메타데이터 목록
- * @param paginationMetadataDto 현재 페이지 번호, 페이지당 항목 수, 전체 페이지 수, 전체 항목 수를 포함한 DTO
+ * @param items          조회된 펌웨어 메타데이터 목록
+ * @param paginationMeta 현재 페이지 번호, 페이지당 항목 수, 전체 페이지 수, 전체 항목 수를 포함한 DTO
  */
 public record FirmwareMetadataWithPageResponseDto(
-        List<FirmwareMetadataResponseDto> content,
-        PaginationMetadataDto paginationMetadataDto
+        List<FirmwareMetadataResponseDto> items,
+        PaginationMetadataDto paginationMeta
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataWithPageResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataWithPageResponseDto.java
@@ -1,0 +1,15 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.util.List;
+
+/**
+ * 페이징된 펌웨어 메타데이터 목록과 페이지 정보가 포함된 응답 DTO 입니다.
+ *
+ * @param content               조회된 펌웨어 메타데이터 목록
+ * @param paginationMetadataDto 현재 페이지 번호, 페이지당 항목 수, 전체 페이지 수, 전체 항목 수를 포함한 DTO
+ */
+public record FirmwareMetadataWithPageResponseDto(
+        List<FirmwareMetadataResponseDto> content,
+        PaginationMetadataDto paginationMetadataDto
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginatedFirmwareMetadataResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginatedFirmwareMetadataResponseDto.java
@@ -1,9 +1,0 @@
-package com.coffee_is_essential.iot_cloud_ota.dto;
-
-import java.util.List;
-
-public record PaginatedFirmwareMetadataResponseDto(
-        List<FirmwareMetadataResponseDto> firmwareMetadataResponseDtos,
-        PaginationMetadataDto paginationMetadataDto
-) {
-}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginatedFirmwareMetadataResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginatedFirmwareMetadataResponseDto.java
@@ -1,0 +1,9 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.util.List;
+
+public record PaginatedFirmwareMetadataResponseDto(
+        List<FirmwareMetadataResponseDto> firmwareMetadataResponseDtos,
+        PaginationMetadataDto paginationMetadataDto
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
@@ -1,5 +1,13 @@
 package com.coffee_is_essential.iot_cloud_ota.dto;
 
+/**
+ * 페이지네이션에 대한 메타데이터 정보를 포한한 DTO 입니다.
+ *
+ * @param page       현재 페이지 번호 (1부터 시작)
+ * @param limit      페이지당 항목 수
+ * @param totalPage  전체 페이지 수
+ * @param totalCount 전체 항목 수
+ */
 public record PaginationMetadataDto(
         int page,
         int limit,

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
@@ -1,0 +1,9 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+public record PaginationMetadataDto(
+        int page,
+        int limit,
+        int totalPage,
+        long totalCount
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/exception/GlobalExceptionHandler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,11 +18,10 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     /**
-     * 요청 본문(@RequestBody)에서 유효성 검사(@Valid)가 실패했을 때 발생하는 예외를 처리합니다.
-     * 필드별 메시지를 담아 400 BAD_REQUEST 응답을 반환합니다.
+     * {@link MethodArgumentNotValidException} 예외가 발생했을 때 클라이언트에 에러 메시지와 상태 코드를 반환합니다.
      *
      * @param e 유효성 검증 실패로 인해 발생한 MethodArgumentNotValidException
-     * @return 필드별 에러 메시지를 포함한 에러 응답 DTO
+     * @return 필드별 에러 메시지와 HTTP 상태 코드를 포함한 에러 응답 DTO
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> handleValidationError(MethodArgumentNotValidException e) {
@@ -32,5 +32,20 @@ public class GlobalExceptionHandler {
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(errors);
 
         return new ResponseEntity<>(errorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * {@link ResponseStatusException} 예외가 발생했을 때 클라이언트에 에러 메시지와 상태 코드를 반환합니다.
+     *
+     * @param e 처리할 ResponseStatusException 예외
+     * @return 예외 메시지와 HTTP 상태 코드를 포함한 에러 응답 DTO
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponseDto> handleResponseStatusError(ResponseStatusException e) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", e.getReason());
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(errors);
+
+        return new ResponseEntity<>(errorResponseDto, e.getStatusCode());
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -2,6 +2,40 @@ package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
+/**
+ * 펌웨어 메타데이터를 관리하는 JPA 리포지토리 인터페이스입니다.
+ */
 public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMetadata, Long> {
+
+    /**
+     * 지정한 범위(limit, offset)에 따라 생성시각으로 정렬된 펌웨어 메타데이터 목록을 조회합니다.
+     *
+     * @param limit  조회할 항목 수
+     * @param offset 조회 시작 위치
+     * @return 정렬된 펌웨어 메타데이터 목록
+     */
+    @Query(value = """
+            SELECT *
+            FROM firmware_metadata
+            ORDER BY created_at DESC
+            LIMIT :limit
+            OFFSET :offset
+            """, nativeQuery = true)
+    List<FirmwareMetadata> findFirmwareMetadataPage(@Param("limit") int limit, @Param("offset") int offset);
+
+    /**
+     * 펌웨어 메타데이터 테이블의 전체 레코드 수를 반환합니다.
+     *
+     * @return 전체 레코드 수
+     */
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM firmware_metadata
+            """, nativeQuery = true)
+    long countAllFirmwareMetadata();
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -2,10 +2,17 @@ package com.coffee_is_essential.iot_cloud_ota.service;
 
 import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataRequestDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.FirmwareMetadataWithPageResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.PaginationMetadataDto;
 import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
 import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 /**
  * 펌웨어 메타데이터의 비즈니스 로직을 처리하는 서비스 클래스입니다.
@@ -21,6 +28,7 @@ public class FirmwareMetadataService {
      * @param requestDto 저장할 펌웨어 메타데이터 요청 DTO
      * @return 저장된 펌웨어 정보를 담은 응답 DTO
      */
+    @Transactional
     public FirmwareMetadataResponseDto saveFirmwareMetadata(FirmwareMetadataRequestDto requestDto) {
         FirmwareMetadata firmwareMetadata = new FirmwareMetadata(
                 requestDto.version(),
@@ -31,5 +39,36 @@ public class FirmwareMetadataService {
         FirmwareMetadata savedFirmwareMetadata = firmwareMetadataJpaRepository.save(firmwareMetadata);
 
         return FirmwareMetadataResponseDto.from(savedFirmwareMetadata);
+    }
+
+    /**
+     * 페이지 번호와 페이지 크기를 기반으로 펌웨어 메타데이터 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param page  조회할 페이지 번호 (1부터 시작)
+     * @param limit 페이지당 항목 수
+     * @return 조회된 펌웨어 메타데이터 목록과 페이지 메타데이터가 포함된 DTO
+     */
+    @Transactional
+    public FirmwareMetadataWithPageResponseDto findAllWithPagination(int page, int limit) {
+        if (page < 0 || limit < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다.");
+        }
+
+        int offset = (page - 1) * limit;
+        List<FirmwareMetadata> list = firmwareMetadataJpaRepository.findFirmwareMetadataPage(limit, offset);
+        long totalCount = firmwareMetadataJpaRepository.countAllFirmwareMetadata();
+
+        List<FirmwareMetadataResponseDto> content = list.stream()
+                .map(FirmwareMetadataResponseDto::from)
+                .toList();
+
+        PaginationMetadataDto paginationMetadataDto = new PaginationMetadataDto(
+                page,
+                limit,
+                (int) Math.ceil((double) totalCount / limit),
+                totalCount
+        );
+
+        return new FirmwareMetadataWithPageResponseDto(content, paginationMetadataDto);
     }
 }


### PR DESCRIPTION
# Changelog

- `GET /api/firmwares/metadata` API 추가
- Native SQL 기반 쿼리(`LIMIT`, `OFFSET`) 으로 페이징 구현
- page/limit 유효성 검사 (page < 0, limit < 0시 400 에러 반환)

# Testing

- Postman으로` /api/firmwares/meatadata` 요청 및 결과 확인

<img width="519" alt="image" src="https://github.com/user-attachments/assets/2f4e4643-69f0-4e43-aad5-dac839a84d3c" />

# Ops Impact

N/A

# Version Compatibility

N/A
