### PR TITLE
[Backend] 펌웨어 세부 정보 조회 API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/IotCloudOtaApplication.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/IotCloudOtaApplication.java
@@ -11,5 +11,4 @@ public class IotCloudOtaApplication {
     public static void main(String[] args) {
         SpringApplication.run(IotCloudOtaApplication.class, args);
     }
-
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -62,4 +62,17 @@ public class FirmwareController {
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
+
+    /**
+     * 지정한 ID에 해당하는 펌웨어 메타데이터를 조회합니다.
+     *
+     * @param id 조회할 펌웨어 메타데이터의 고유 ID
+     * @return 조회된 펌웨어 메타데이터 정보가 포함된 응답 DTO
+     */
+    @GetMapping("/metadata/{id}")
+    public ResponseEntity<FirmwareMetadataResponseDto> findById(@PathVariable Long id) {
+        FirmwareMetadataResponseDto responseDto = firmwareMetadataService.findById(id);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -4,6 +4,8 @@ import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -17,7 +19,7 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
      *
      * @param limit  조회할 항목 수
      * @param offset 조회 시작 위치
-     * @return 정렬된 펌웨어 메타데이터 목록
+     * @return 정렬된 {@link FirmwareMetadata} 리스트
      */
     @Query(value = """
             SELECT *
@@ -38,4 +40,15 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
             FROM firmware_metadata
             """, nativeQuery = true)
     long countAllFirmwareMetadata();
+
+    /**
+     * 주어진 ID에 해당하는 펌웨어 메타데이터를 조회합니다.
+     * 존재하지 않을 경우 404 NOT_FOUND 예외를 발생시킵니다.
+     *
+     * @param id 조회할 펌웨어 메타데이터의 고유 ID
+     * @return 조회된 {@link FirmwareMetadata} 엔티티
+     */
+    default FirmwareMetadata findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "[ID: " + id + "] 펌웨어를 찾을 수 없습니다."));
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -48,7 +48,6 @@ public class FirmwareMetadataService {
      * @param limit 페이지당 항목 수
      * @return 조회된 펌웨어 메타데이터 목록과 페이지 메타데이터가 포함된 DTO
      */
-    @Transactional
     public FirmwareMetadataWithPageResponseDto findAllWithPagination(int page, int limit) {
         if (page < 0 || limit < 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다.");
@@ -70,5 +69,17 @@ public class FirmwareMetadataService {
         );
 
         return new FirmwareMetadataWithPageResponseDto(content, paginationMetadataDto);
+    }
+
+    /**
+     * 주어진 ID에 해당하는 펌웨어 메타데이터를 조회하여 응답 DTO로 변환합니다.
+     *
+     * @param id 조회할 펌웨어 메타데이터의 고유 ID
+     * @return 조회된 펌웨어 메타데이터의 응답 DTO
+     */
+    public FirmwareMetadataResponseDto findById(Long id) {
+        FirmwareMetadata findFirmwareMetadata = firmwareMetadataJpaRepository.findByIdOrElseThrow(id);
+
+        return FirmwareMetadataResponseDto.from(findFirmwareMetadata);
     }
 }


### PR DESCRIPTION
# Changelog

- `GET /api/firmwares/metadata/{id}` API 추가
- 존재하지 않는 ID 요청 시 `404 NOT_FOUND` 예외 처리

# Testing

- 로컬에서 Postman을 이용해 테스트를 진행하였습니다.
- 존재하는 ID로 `/metadata/{id}` 요청

<img width="471" alt="image" src="https://github.com/user-attachments/assets/4d5603dd-7609-42c0-881a-f22ed6c49857" />

- 존재하지 않는 ID로 `/metadata/{id}` 요청

<img width="475" alt="image" src="https://github.com/user-attachments/assets/5157c316-114d-4d7b-b752-ee584ec6b530" />

# Ops Impact

N/A

# Version Compatibility

N/A
