### PR TITLE
[Backend] Presigned URL 발급 로직 수정

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -23,12 +23,11 @@ public class FirmwareController {
      * Presigned URL을 발급하여 클라이언트가 인증 없이 S3에 펌웨어 파일을 업로드할 수 있도록 합니다.
      *
      * @param requestDto 업로드할 버전 및 파일명을 포함한 요청 DTO
-     * @return 업로드 가능한 Presigned URL을 포함한 응답 DTO
+     * @return 업로드 가능한 S3 Presigne URL 및 실제 저장 경로가 포함된 응답 DTO
      */
-    @PostMapping("/presigned_url")
-    public ResponseEntity<PresignedUrlResponseDto> issuePresignedUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
-        String url = s3Service.getPresignedUrl(requestDto.version(), requestDto.filename());
-        PresignedUrlResponseDto responseDto = new PresignedUrlResponseDto(url);
+    @GetMapping("/presigned_upload")
+    public ResponseEntity<UploadPresignedUrlResponseDto> issuePresignedUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
+        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUrl(requestDto.version(), requestDto.filename());
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -75,4 +74,10 @@ public class FirmwareController {
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
+
+//    @GetMapping("/presigned_download")
+//    public ResponseEntity<PresignedUrlResponseDto> getPresignedDownloadUrl() {
+//
+//        return null;
+//    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/UploadPresignedUrlResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/UploadPresignedUrlResponseDto.java
@@ -4,9 +4,11 @@ package com.coffee_is_essential.iot_cloud_ota.dto;
  * S3 Presigned URL 응답 DTO 입니다.
  * 클라이언트가 해당 URL을 사용하여 S3에 직접 업로드할 수 있습니다.
  *
- * @param url S3에 PUT 요청을 보낼 수 있는 Presigned URL
+ * @param url    S3에 PUT 요청을 보낼 수 있는 Presigned URL
+ * @param s3Path S3에 실제 저장될 Key
  */
-public record PresignedUrlResponseDto(
-        String url
+public record UploadPresignedUrlResponseDto(
+        String url,
+        String s3Path
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
@@ -3,12 +3,14 @@ package com.coffee_is_essential.iot_cloud_ota.service;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.coffee_is_essential.iot_cloud_ota.dto.UploadPresignedUrlResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.net.URL;
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * S3Service 클래스는 AWS S3 Presigned URL 발급 기능을 제공합니다.
@@ -18,24 +20,24 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    private String bucketName;
 
     private final AmazonS3 amazonS3;
 
     /**
-     * 지정한 prefix와 파일명으로 S3 Presigned URL을 생성합니다.
+     * 지정한 버전과 파일 이름을 기반으로 S3에 업로드할 수 있는 Presigned URL을 생성합니다.
      *
-     * @param prefix   업로드 경로에 사용할 접두사 (예: "v1.0.0")
-     * @param fileName 저장할 파일 이름
-     * @return Presigned URL 문자열 (PUT 요청용)
+     * @param version  파일 버전 (예: "v1.0.0")
+     * @param fileName 저장할 파일 이름 (예: "firmware.zip")
+     * @return 업로드용 Presigned URL 및 S3 저장 경로가 포함된 DTO
      */
-    public String getPresignedUrl(String prefix, String fileName) {
-        String path = createPath(prefix, fileName);
+    public UploadPresignedUrlResponseDto getPresignedUrl(String version, String fileName) {
+        String path = createPath(version, fileName);
 
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = generatePresignedUrlRequest(bucket, path);
-        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = generatePresignedUrlRequest(bucketName, path);
+        String url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
 
-        return url.toString();
+        return new UploadPresignedUrlResponseDto(url, path);
     }
 
     /**
@@ -56,28 +58,29 @@ public class S3Service {
 
     /**
      * Presigned URL의 만료 시간을 반환합니다.
-     * 기본 유효 시간은 현재 시간으로부터 2분입니다.
+     * 기본 유효 시간은 현재 시간으로부터 5분입니다.
      *
      * @return 만료 시간 (Date 객체)
      */
     private Date getPresignedUrlExpiration() {
         Date expiration = new Date();
         long expTimeMillis = expiration.getTime();
-        expTimeMillis += 1000 * 60 * 2;
+        expTimeMillis += 1000 * 60 * 5;
         expiration.setTime(expTimeMillis);
 
         return expiration;
     }
 
     /**
-     * prefix와 파일명을 결합하여 S3 경로를 생성합니다.
+     * 파일버전, UUID, 파일명을 결합하여 S3 경로를 생성합니다.
      *
-     * @param prefix   경로 접두사
+     * @param version  파일 버전
      * @param fileName 파일 이름
-     * @return 결합된 경로 문자열 (예: "v1.0.0/firmware.zip")
+     * @return 결합된 경로 문자열 (예: "v1.0.0/uuid/firmware.zip")
      */
-    private String createPath(String prefix, String fileName) {
+    private String createPath(String version, String fileName) {
+        String uuid = UUID.randomUUID().toString();
 
-        return String.format("%s/%s", prefix, fileName);
+        return String.format("%s/%s/%s", version, uuid, fileName);
     }
 }


### PR DESCRIPTION
# Changelog

- S3 Presigned URL 발급 로직을 리팩토링하여 UploadPresignedUrlResponseDto를 반환하도록 변경
- URL 발급 시 S3 저장 경로를 명시적으로 함께 응답
- UUID 기반 고유 경로를 생성하여 파일 중복 방지 및 추적성 개선

# Testing

- 로컬 환경에서 `GET /firmwares/presignd_upload` API 테스트 진행
   - 요청: version, fileName 포함 Json Body 전송
   - 응답: 정상적으로 Presigned URL과 S3 경로 반환 확인

<img width="575" alt="image" src="https://github.com/user-attachments/assets/25d0015c-4185-41b9-8b3b-476ddc72e170" />

# Ops Impact

<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
