### PR TITLE
[Backend] firmware_metadata table 수정

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
@@ -16,19 +16,19 @@ public class MockDataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.01", "24.04.01.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.02", "24.04.02.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.03", "24.04.03.ino", "연두해요 연두 광고를 업로드하였습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.04", "24.04.04.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.01", "24.04.01.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.01/uuid1/24.04.01.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.02", "24.04.02.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.02/uuid2/24.04.02.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.03", "24.04.03.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.03/uuid3/24.04.03.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.04", "24.04.04.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.04/uuid4/24.04.04.ino"));
 
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.05", "24.04.05.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.06", "24.04.06.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.07", "24.04.07.ino", "연두해요 연두 광고를 업로드하였습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.08", "24.04.08.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.05", "24.04.05.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.05/uuid5/24.04.05.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.06", "24.04.06.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.06/uuid6/24.04.06.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.07", "24.04.07.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.07/uuid7/24.04.07.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.08", "24.04.08.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.08/uuid8/24.04.08.ino"));
 
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.09", "24.04.09.ino", "광고가 표시되지 않는 버그를 수정했습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.10", "24.04.10.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.11", "24.04.11.ino", "연두해요 연두 광고를 업로드하였습니다."));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.12", "24.04.12.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다."));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.09", "24.04.09.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.09/uuid9/24.04.09.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.10", "24.04.10.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.10/uuid10/24.04.10.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.11", "24.04.11.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.11/uuid11/24.04.11.ino"));
+        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.12", "24.04.12.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.12/uuid12/24.04.12.ino"));
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -27,7 +27,7 @@ public class FirmwareController {
      */
     @GetMapping("/presigned_upload")
     public ResponseEntity<UploadPresignedUrlResponseDto> issuePresignedUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
-        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUrl(requestDto.version(), requestDto.filename());
+        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUrl(requestDto.version(), requestDto.fileName());
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareMetadataRequestDto.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
  * @param version     펌웨어 버전
  * @param fileName    펌웨어 파일 이름
  * @param releaseNote 릴리즈 노트
+ * @param s3Path      S3 버킷 내 파일 경로
  */
 public record FirmwareMetadataRequestDto(
         @NotBlank(message = "버전은 비어있을 수 없습니다.")
@@ -15,6 +16,8 @@ public record FirmwareMetadataRequestDto(
         @NotBlank(message = "파일명은 비어있을 수 없습니다.")
         String fileName,
         @NotBlank(message = "릴리즈 노트는 비어있을 수 없습니다.")
-        String releaseNote
+        String releaseNote,
+        @NotBlank(message = "S3 Path는 비어있을 수 없습니다.")
+        String s3Path
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PresignedUrlRequestDto.java
@@ -7,12 +7,12 @@ import jakarta.validation.constraints.NotBlank;
  * 클라이언트가 업로드할 펌웨어 파일의 버전과 파일명을 전달합니다.
  *
  * @param version  업로드할 펌웨어의 버전 (예: "v1.0.0")
- * @param filename 업로드할 파일 이름 (예: "firmware.zip)
+ * @param fileName 업로드할 파일 이름 (예: "firmware.zip)
  */
 public record PresignedUrlRequestDto(
         @NotBlank(message = "버전은 비어있을 수 없습니다.")
         String version,
         @NotBlank(message = "파일명은 비어있을 수 없습니다.")
-        String filename
+        String fileName
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
@@ -26,9 +26,13 @@ public class FirmwareMetadata extends BaseEntity {
     @Column(nullable = false)
     private String releaseNote;
 
-    public FirmwareMetadata(String version, String fileName, String releaseNote) {
+    @Column(nullable = false)
+    private String s3Path;
+    
+    public FirmwareMetadata(String version, String fileName, String releaseNote, String s3Path) {
         this.version = version;
         this.fileName = fileName;
         this.releaseNote = releaseNote;
+        this.s3Path = s3Path;
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -33,7 +33,8 @@ public class FirmwareMetadataService {
         FirmwareMetadata firmwareMetadata = new FirmwareMetadata(
                 requestDto.version(),
                 requestDto.fileName(),
-                requestDto.releaseNote()
+                requestDto.releaseNote(),
+                requestDto.s3Path()
         );
 
         FirmwareMetadata savedFirmwareMetadata = firmwareMetadataJpaRepository.save(firmwareMetadata);


### PR DESCRIPTION
# Changelog

- FirmwareMetadata 엔티티에 s3Path 필드 추가
   - S3 Presigned URL 발급 시 생성된 파일 저장 경로를 DB에 저장하기 위함
 
# Testing

- 로컬 환경에서 엔티티 변경 사항 변경 후 테스트
- DB에 정상적으로 s3Path 칼럼이 추가됨을 확인함

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/52358a14-4f43-4699-ae0b-7919bd6e94e2" />

# Ops Impact

N/A

# Version Compatibility

N/A
