### PR TITLE
[Backend] 펌웨어 파일 다운로드 요청  API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -26,8 +26,8 @@ public class FirmwareController {
      * @return 업로드 가능한 S3 Presigne URL 및 실제 저장 경로가 포함된 응답 DTO
      */
     @GetMapping("/presigned_upload")
-    public ResponseEntity<UploadPresignedUrlResponseDto> issuePresignedUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
-        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUrl(requestDto.version(), requestDto.fileName());
+    public ResponseEntity<UploadPresignedUrlResponseDto> getPresignedUploadUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
+        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUploadUrl(requestDto.version(), requestDto.fileName());
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -63,7 +63,7 @@ public class FirmwareController {
     }
 
     /**
-     * 지정한 ID에 해당하는 펌웨어 메타데이터를 조회합니다.
+     * 지정한 펌웨어 ID에 해당하는 펌웨어 메타데이터를 조회합니다.
      *
      * @param id 조회할 펌웨어 메타데이터의 고유 ID
      * @return 조회된 펌웨어 메타데이터 정보가 포함된 응답 DTO
@@ -75,9 +75,16 @@ public class FirmwareController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
-//    @GetMapping("/presigned_download")
-//    public ResponseEntity<PresignedUrlResponseDto> getPresignedDownloadUrl() {
-//
-//        return null;
-//    }
+    /**
+     * 지정한 펌웨어 ID에 해당하는 펌웨어의 S3 Presigned 다운로드 URL을 발급합니다.
+     *
+     * @param id 다운로드할 펌웨어 메타데이터의 고유 ID
+     * @return 다운로드 가능한 Presigned URL을 담은 응답 DTO
+     */
+    @GetMapping("/{id}/presigned_download")
+    public ResponseEntity<DownloadPresignedUrlResponseDto> getPresignedDownloadUrl(@PathVariable Long id) {
+        DownloadPresignedUrlResponseDto responseDto = s3Service.getPresignedDownloadUrl(id);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DownloadPresignedUrlResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DownloadPresignedUrlResponseDto.java
@@ -1,0 +1,11 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+/**
+ * S3 Presigned 다운로드 URL 응답 DTO 입니다.
+ *
+ * @param url S3에 GET 요청을 보낼 수 있는 Presigned URL
+ */
+public record DownloadPresignedUrlResponseDto(
+        String url
+) {
+}


### PR DESCRIPTION
# Changelog

- GET /api/firmwares/{id}/presigned_download 엔트포인트 구현
- 지정된 펌웨어 ID에 대해 S3 Presigned 다운오르 URL을 생성하여 반환
- FirmwareMetadata 엔티티의 s3Path를 기반으로 Presigned URL 생성
- S3Service에 다운로드용 Presigned URL 생성 메서드 추가

# Testing

- 로컬 환경에서 /api/firmwares/{id}/presigned_download API 호출 테스트
  - 유효한 ID 요청 시 200 OK 및 유효한 Presigned URL 반환 확인
  - 존재하지 않은 ID 요청 시 404 NOT_FOUND 반환 확인
 
<img width="722" alt="스크린샷 2025-07-09 오후 5 17 45" src="https://github.com/user-attachments/assets/79f98400-27c5-4ddb-a5b6-2d1f3b3fd028" />

# Ops Impact

N/A

# Version Compatibility

N/A
