### PR TITLE
[Backend] Region 테이블 생성 및 초기 데이터 구성

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Region.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Region.java
@@ -4,6 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+/**
+ * AWS 리전 정보를 데이터베이스에 저장하기 위한 엔티티 클래스 입니다.
+ */
 @Entity
 public class Region {
     @Id

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Region.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Region.java
@@ -1,0 +1,17 @@
+package com.coffee_is_essential.iot_cloud_ota.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Region {
+    @Id
+    private Long id;
+
+    @Column(name = "region_id", nullable = false, unique = true)
+    private String regionId;
+
+    @Column(name = "region_name", nullable = false)
+    private String regionName;
+}

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -23,5 +23,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # data.sql? ?? ????? ??
 spring.sql.init.mode=always
+
 # ??? ?? ? data.sql ??
 spring.jpa.defer-datasource-initialization=true

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -20,3 +20,8 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# data.sql? ?? ????? ??
+spring.sql.init.mode=always
+# ??? ?? ? data.sql ??
+spring.jpa.defer-datasource-initialization=true

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -21,8 +21,5 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# data.sql? ?? ????? ??
 spring.sql.init.mode=always
-
-# ??? ?? ? data.sql ??
 spring.jpa.defer-datasource-initialization=true

--- a/backend/iot-cloud-ota/src/main/resources/data.sql
+++ b/backend/iot-cloud-ota/src/main/resources/data.sql
@@ -1,0 +1,7 @@
+INSERT INTO region (id, region_id, region_name) VALUES (1, 'us-west-1', '미국 북부 캘리포니아');
+INSERT INTO region (id, region_id, region_name) VALUES (2, 'us-east-1', '미국 북부 버지니아');
+INSERT INTO region (id, region_id, region_name) VALUES (3, 'ap-south-1', '인도 뭄바이');
+INSERT INTO region (id, region_id, region_name) VALUES (4, 'ap-northeast-2', '서울');
+INSERT INTO region (id, region_id, region_name) VALUES (5, 'ap-northeast-3', '오사카');
+INSERT INTO region (id, region_id, region_name) VALUES (6, 'ap-west-1', '인도');
+INSERT INTO region (id, region_id, region_name) VALUES (7, 'ap-southeast-3', '자카르타');


### PR DESCRIPTION
# Changelog

- region 엔티티 추가 (`id`, `region_id`, `region_name`)
- 초기 리전 데이터 삽입용 `data.sql` 구성
- `application.properties`에 `data.sql` 자동 실행 설정 추가

# Testing

- 애플리케이션 실행 후 MySQL에서 `SELECT * FROM region;` 실행

<img width="441" alt="image" src="https://github.com/user-attachments/assets/45140ce3-41a0-49bc-b829-871da79b7044" />


# Ops Impact

- region 테이블 신규 생성됨
- 초기 데이터가 삽입되므로 운영 DB에 적용 시 주의 필요

# Version Compatibility

- N/A
