### PR TITLE
[Backend] 리전 summary 리스트 요청 API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
@@ -1,77 +1,78 @@
-package com.coffee_is_essential.iot_cloud_ota.component;
-
-import com.coffee_is_essential.iot_cloud_ota.entity.Device;
-import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
-import com.coffee_is_essential.iot_cloud_ota.entity.Division;
-import com.coffee_is_essential.iot_cloud_ota.entity.Region;
-import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.GroupJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-/**
- * 애플리케이션 시작 시 테스트용 펌웨어 메타데이터를 DB에 삽입하는 컴포넌트입니다.
- */
-@Component
-@RequiredArgsConstructor
-public class MockDataInitializer implements CommandLineRunner {
-    private final FirmwareMetadataJpaRepository firmwareMetadataJpaRepository;
-    private final RegionJpaRepository regionJpaRepository;
-    private final GroupJpaRepository groupJpaRepository;
-    private final DeviceJpaRepository deviceJpaRepository;
-
-    @Override
-    public void run(String... args) throws Exception {
-        saveFirmwareMetadata();
-        saveRegion();
-        saveGroup();
-        saveDevice();
-    }
-
-    private void saveFirmwareMetadata() {
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.01", "24.04.01.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.01/uuid1/24.04.01.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.02", "24.04.02.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.02/uuid2/24.04.02.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.03", "24.04.03.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.03/uuid3/24.04.03.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.04", "24.04.04.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.04/uuid4/24.04.04.ino"));
-
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.05", "24.04.05.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.05/uuid5/24.04.05.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.06", "24.04.06.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.06/uuid6/24.04.06.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.07", "24.04.07.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.07/uuid7/24.04.07.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.08", "24.04.08.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.08/uuid8/24.04.08.ino"));
-
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.09", "24.04.09.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.09/uuid9/24.04.09.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.10", "24.04.10.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.10/uuid10/24.04.10.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.11", "24.04.11.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.11/uuid11/24.04.11.ino"));
-        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.12", "24.04.12.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.12/uuid12/24.04.12.ino"));
-    }
-
-    private void saveRegion() {
-        regionJpaRepository.save(new Region("us-west-1", "미국 북부 캘리포니아"));
-        regionJpaRepository.save(new Region("us-east-1", "미국 북부 버지니아"));
-        regionJpaRepository.save(new Region("ap-south-1", "인도 뭄바이"));
-        regionJpaRepository.save(new Region("ap-northeast-2", "서울"));
-        regionJpaRepository.save(new Region("ap-northeast-3", "오사카"));
-        regionJpaRepository.save(new Region("ap-west-1", "인도"));
-        regionJpaRepository.save(new Region("ap-southeast-3", "자카르타"));
-    }
-
-    private void saveGroup() {
-        groupJpaRepository.save(new Division("dmeowk-203", "서울 모수"));
-        groupJpaRepository.save(new Division("wmeotc-391", "부산 스타벅스 광안리점"));
-        groupJpaRepository.save(new Division("wjrpvo-100", "오꾸닭 신림점"));
-        groupJpaRepository.save(new Division("woeprz-009", "네이버 판교 본사"));
-    }
-
-    private void saveDevice() {
-        deviceJpaRepository.save(new Device("bartooler-001", null, null));
-        deviceJpaRepository.save(new Device("bartooler-002", null, null));
-        deviceJpaRepository.save(new Device("bartooler-003", null, null));
-        deviceJpaRepository.save(new Device("bartooler-004", null, null));
-        deviceJpaRepository.save(new Device("bartooler-005", null, null));
-        deviceJpaRepository.save(new Device("bartooler-006", null, null));
-        deviceJpaRepository.save(new Device("bartooler-007", null, null));
-    }
-}
+//package com.coffee_is_essential.iot_cloud_ota.component;
+//
+//import com.coffee_is_essential.iot_cloud_ota.entity.Device;
+//import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
+//import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+//import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+//import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
+//import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
+//import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
+//import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
+//import com.coffee_is_essential.iot_cloud_ota.service.DeviceService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+///**
+// * 애플리케이션 시작 시 테스트용 펌웨어 메타데이터를 DB에 삽입하는 컴포넌트입니다.
+// */
+//@Component
+//@RequiredArgsConstructor
+//public class MockDataInitializer implements CommandLineRunner {
+//    private final FirmwareMetadataJpaRepository firmwareMetadataJpaRepository;
+//    private final RegionJpaRepository regionJpaRepository;
+//    private final DivisionJpaRepository divisionJpaRepository;
+//    private final DeviceService deviceService;
+//
+//    @Override
+//    public void run(String... args) throws Exception {
+//        saveFirmwareMetadata();
+//        saveRegion();
+//        saveGroup();
+//        saveDevice();
+//    }
+//
+//    private void saveFirmwareMetadata() {
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.01", "24.04.01.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.01/uuid1/24.04.01.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.02", "24.04.02.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.02/uuid2/24.04.02.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.03", "24.04.03.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.03/uuid3/24.04.03.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.04", "24.04.04.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.04/uuid4/24.04.04.ino"));
+//
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.05", "24.04.05.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.05/uuid5/24.04.05.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.06", "24.04.06.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.06/uuid6/24.04.06.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.07", "24.04.07.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.07/uuid7/24.04.07.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.08", "24.04.08.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.08/uuid8/24.04.08.ino"));
+//
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.09", "24.04.09.ino", "광고가 표시되지 않는 버그를 수정했습니다.", "24.04.09/uuid9/24.04.09.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.10", "24.04.10.ino", "원두 선택 버튼이 클릭되지 않는 버그를 수정했습니다", "24.04.10/uuid10/24.04.10.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.11", "24.04.11.ino", "연두해요 연두 광고를 업로드하였습니다.", "24.04.11/uuid11/24.04.11.ino"));
+//        firmwareMetadataJpaRepository.save(new FirmwareMetadata("24.04.12", "24.04.12.ino", "동원참치 캔 광고가 표시되지 않는 버그를 수정하였습니다.", "24.04.12/uuid12/24.04.12.ino"));
+//    }
+//
+//    private void saveRegion() {
+//        regionJpaRepository.save(new Region("us-west-1", "미국 북부 캘리포니아"));
+//        regionJpaRepository.save(new Region("us-east-1", "미국 북부 버지니아"));
+//        regionJpaRepository.save(new Region("ap-south-1", "인도 뭄바이"));
+//        regionJpaRepository.save(new Region("ap-northeast-2", "서울"));
+//        regionJpaRepository.save(new Region("ap-northeast-3", "오사카"));
+//        regionJpaRepository.save(new Region("ap-west-1", "인도"));
+//        regionJpaRepository.save(new Region("ap-southeast-3", "자카르타"));
+//    }
+//
+//    private void saveGroup() {
+//        divisionJpaRepository.save(new Division("dmeowk-203", "서울 모수"));
+//        divisionJpaRepository.save(new Division("wmeotc-391", "부산 스타벅스 광안리점"));
+//        divisionJpaRepository.save(new Division("wjrpvo-100", "오꾸닭 신림점"));
+//        divisionJpaRepository.save(new Division("woeprz-009", "네이버 판교 본사"));
+//    }
+//
+//    private void saveDevice() {
+//        deviceService.saveDevice("bartooler-001", 1L, 1L);
+//        deviceService.saveDevice("bartooler-002", 1L, 1L);
+//        deviceService.saveDevice("bartooler-003", 4L, 1L);
+//        deviceService.saveDevice("bartooler-004", 3L, 3L);
+//        deviceService.saveDevice("bartooler-005", 3L, 3L);
+//        deviceService.saveDevice("bartooler-006", 3L, 3L);
+//        deviceService.saveDevice("bartooler-007", 3L, 3L);
+//    }
+//}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
@@ -1,0 +1,35 @@
+package com.coffee_is_essential.iot_cloud_ota.controller;
+
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.service.RegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 리전 관련 요청을 처리하는 REST 컨트롤러 입니다.
+ */
+@RestController
+@RequestMapping("/api/regions")
+@RequiredArgsConstructor
+public class RegionController {
+    private final RegionService regionService;
+
+    /**
+     * 전체 리전의 요약 정보를 조회합니다.
+     * 각 리전에는 몇 개의 디바이스가 등록되어 있는지를 포함한 정보가 반환됩니다.
+     *
+     * @return 리전 ID, 리전 코드, 리전 이름, 등록된 디바이스 수를 포함한 리스트와 HTTP 200 OK 응답
+     */
+    @GetMapping
+    public ResponseEntity<List<RegionSummaryResponseDto>> findRegionSummary() {
+        List<RegionSummaryResponseDto> list = regionService.findRegionSummary();
+
+        return new ResponseEntity<>(list, HttpStatus.OK);
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/RegionSummary.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/RegionSummary.java
@@ -1,0 +1,17 @@
+package com.coffee_is_essential.iot_cloud_ota.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 리전과 관련된 요약 정보를 나타내는 도메인 클래스입니다.
+ * 리전 ID, 리전 코드, 리전 이름, 해당 리전에 속한 디바이스 개수를 포함합니다.
+ */
+@Getter
+@AllArgsConstructor
+public class RegionSummary {
+    private Long regionId;
+    private String regionCode;
+    private String regionName;
+    private Long count;
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionSummaryResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionSummaryResponseDto.java
@@ -1,0 +1,27 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.domain.RegionSummary;
+
+/**
+ * 리전 요약 정보를 클라이언트에 응답하기 위한 DTO 입니다.
+ *
+ * @param regionId   리전 ID
+ * @param regionCode 리전 코드 (예: ap-northeast-2)
+ * @param regionName 리전 이름 (예: 서울)
+ * @param count      해당 리전에 등록된 디바이스 수
+ */
+public record RegionSummaryResponseDto(
+        Long regionId,
+        String regionCode,
+        String regionName,
+        Long count
+) {
+    public static RegionSummaryResponseDto from(RegionSummary regionSummary) {
+        return new RegionSummaryResponseDto(
+                regionSummary.getRegionId(),
+                regionSummary.getRegionCode(),
+                regionSummary.getRegionName(),
+                regionSummary.getCount()
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DivisionJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DivisionJpaRepository.java
@@ -1,0 +1,18 @@
+package com.coffee_is_essential.iot_cloud_ota.repository;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public interface DivisionJpaRepository extends JpaRepository<Division, Long> {
+    /**
+     * 주어진 ID로 디비전을 조회하고, 존재하지 않을 경우 {@link ResponseStatusException} 예외를 발생시킵니다.
+     *
+     * @param id 조회할 디비전의 ID
+     * @return 존재하는 디비전 엔티티
+     */
+    default Division findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "[ID: " + id + "] 그룹을 찾을 수 없습니다."));
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/GroupJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/GroupJpaRepository.java
@@ -1,7 +1,0 @@
-package com.coffee_is_essential.iot_cloud_ota.repository;
-
-import com.coffee_is_essential.iot_cloud_ota.entity.Division;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface GroupJpaRepository extends JpaRepository<Division, Long> {
-}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/RegionJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/RegionJpaRepository.java
@@ -1,8 +1,36 @@
 package com.coffee_is_essential.iot_cloud_ota.repository;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.RegionSummary;
 import com.coffee_is_essential.iot_cloud_ota.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 public interface RegionJpaRepository extends JpaRepository<Region, Long> {
-    
+    /**
+     * 주어진 리전 ID로 리전을 조회하고, 없을 경우 {@link ResponseStatusException} 예외를 발생시킵니다.
+     *
+     * @param id 조회할 리전의 ID
+     * @return 존재하는 리전 엔티티
+     */
+    default Region findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "[ID: " + id + "] 리전을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 리전별 디바이스 개수를 요약 조회합니다.
+     * 네이티브 SQL 쿼리를 사용하여 각 리전에 속한 디바이스의 개수를 집계합니다.
+     *
+     * @return RegionSummary 리스트 (regionId, regionCode, regionName, count)
+     */
+    @Query(value = """
+            SELECT r.id AS regionId , region_code AS regionCode, region_name as regionName, COUNT(*) AS count
+            FROM region r
+            JOIN device d ON r.id = d.region_id
+            GROUP BY r.id
+            """, nativeQuery = true)
+    List<RegionSummary> findRegionSummary();
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -1,0 +1,33 @@
+package com.coffee_is_essential.iot_cloud_ota.service;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Device;
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
+import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
+import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DeviceService {
+    private final RegionJpaRepository regionJpaRepository;
+    private final DivisionJpaRepository divisionJpaRepository;
+    private final DeviceJpaRepository deviceJpaRepository;
+
+    /**
+     * 새로운 디바이스를 생성하고 저장합니다.
+     *
+     * @param deviceName 디바이스 이름
+     * @param regionId   연결할 리전의 ID
+     * @param divisionId 연결할 디비전의 ID
+     */
+    public void saveDevice(String deviceName, Long regionId, Long divisionId) {
+        Region region = regionJpaRepository.findByIdOrElseThrow(regionId);
+        Division division = divisionJpaRepository.findByIdOrElseThrow(divisionId);
+        Device device = new Device(deviceName, division, region);
+
+        deviceJpaRepository.save(device);
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
@@ -1,0 +1,27 @@
+package com.coffee_is_essential.iot_cloud_ota.service;
+
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RegionService {
+    private final RegionJpaRepository regionJpaRepository;
+
+    /**
+     * 각 리전에 등록된 디바이스 수 요약 정보를 조회합니다.
+     *
+     * @return RegionSummaryResponseDto 리스트 (regionId, regionCode, regionName, count 포함)
+     */
+    public List<RegionSummaryResponseDto> findRegionSummary() {
+
+        return regionJpaRepository.findRegionSummary()
+                .stream()
+                .map(RegionSummaryResponseDto::from)
+                .toList();
+    }
+}

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=iot-cloud-ota
 # Import .env file
 spring.config.import=optional:file:.env[.properties]
 # JPA
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 # AWS


### PR DESCRIPTION
# Changelog

- `GET /api/regions` 엔드포인트 추가
- 리전별 디바이스 등록 현황 을 조회하는 기능 구현
- `Region`, `Device` 테이블 조인 후 `RegionSummaryResponseDto`로 응답

# Testing

- Postman을 이용해 `GET /api/regions` 호출

<img width="467" height="392" alt="image" src="https://github.com/user-attachments/assets/7f3eddd5-4c93-4c31-bb8b-9e018a15e3a0" />

# Ops Impact

N/A

# Version Compatibility

N/A
