### PR TITLE
[Backend] 펌웨어 메타데이터 검색 기능 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -48,16 +48,18 @@ public class FirmwareController {
     /**
      * 펌웨어 메타데이터 목록을 페이지네이션하여 조회합니다.
      *
-     * @param page  조회할 페이지 번호 (기본값: 1)
-     * @param limit 페이지당 항목 수 (기본값: 10)
+     * @param page   조회할 페이지 번호 (기본값: 1)
+     * @param limit  페이지당 항목 수 (기본값: 10)
+     * @param search 검색어 (선택 사항) - 펌웨어 버전 또는 릴리즈 노트 내용을 기준으로 검색
      * @return 페이징된 펌웨어 메타데이터 목록과 페이지 정보가 포함된 응답 DTO
      */
     @GetMapping("/metadata")
     public ResponseEntity<FirmwareMetadataWithPageResponseDto> findAllWithPagination(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int limit
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(required = false) String search
     ) {
-        FirmwareMetadataWithPageResponseDto responseDto = firmwareMetadataService.findAllWithPagination(page, limit);
+        FirmwareMetadataWithPageResponseDto responseDto = firmwareMetadataService.findAllWithPagination(page, limit, search);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -19,7 +19,7 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
      *
      * @param limit  조회할 항목 수
      * @param offset 조회 시작 위치
-     * @return 정렬된 {@link FirmwareMetadata} 리스트
+     * @return 검색된 {@link FirmwareMetadata} 리스트
      */
     @Query(value = """
             SELECT *
@@ -51,4 +51,39 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
     default FirmwareMetadata findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "[ID: " + id + "] 펌웨어를 찾을 수 없습니다."));
     }
+
+    /**
+     * 검색어에 해당하는 펌웨어 메타데이터를 페이징하여 조회합니다.
+     * version 또는 release_note 컬럼에 검색어가 포함된 경우를 조회합니다.
+     *
+     * @param limit  조회할 항목 수
+     * @param offset 조회 시작 위치
+     * @param search 검색어
+     * @return 검색된 {@link FirmwareMetadata} 리스트
+     */
+    @Query(value = """
+            SELECT *
+            FROM firmware_metadata
+            WHERE version LIKE :search
+            OR release_note LIKE :search
+            ORDER BY created_at DESC
+            LIMIT :limit
+            OFFSET :offset       
+            """, nativeQuery = true
+    )
+    List<FirmwareMetadata> searchFirmwareMetadataByVersionOrReleaseNote(@Param("limit") int limit, @Param("offset") int offset, @Param("search") String search);
+
+    /**
+     * 검색어에 해당하는 펌웨어 메타데이터 총 개수를 반환합니다.
+     *
+     * @param search 검색어 (version 또는 release_note에 포함될 문자열)
+     * @return 검색 결과에 해당하는 총 레코드 수
+     */
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM firmware_metadata
+            WHERE version LIKE :search
+            OR release_note LIKE :search
+            """, nativeQuery = true)
+    long countFirmwareMetadataByVersionOrReleaseNote(@Param("search") String search);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -44,19 +44,31 @@ public class FirmwareMetadataService {
 
     /**
      * 페이지 번호와 페이지 크기를 기반으로 펌웨어 메타데이터 목록을 페이지네이션하여 조회합니다.
+     * 검색어가 제공된 경우, 펌웨어 버전(version) 또는 릴리즈 노트(release_note)에 해당 문자열이 포함된 항목만 조회합니다.
+     * 그렇지 않은 경우 전체 데이터를 페이지네이션하여 반환합니다.
      *
-     * @param page  조회할 페이지 번호 (1부터 시작)
-     * @param limit 페이지당 항목 수
+     * @param page   조회할 페이지 번호 (1부터 시작)
+     * @param limit  페이지당 항목 수
+     * @param search (선택) 검색어 - version 또는 release_note 컬럼에 포함될 문자열
      * @return 조회된 펌웨어 메타데이터 목록과 페이지 메타데이터가 포함된 DTO
      */
-    public FirmwareMetadataWithPageResponseDto findAllWithPagination(int page, int limit) {
+    public FirmwareMetadataWithPageResponseDto findAllWithPagination(int page, int limit, String search) {
         if (page < 0 || limit < 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다.");
         }
 
         int offset = (page - 1) * limit;
-        List<FirmwareMetadata> list = firmwareMetadataJpaRepository.findFirmwareMetadataPage(limit, offset);
-        long totalCount = firmwareMetadataJpaRepository.countAllFirmwareMetadata();
+        List<FirmwareMetadata> list;
+        long totalCount;
+
+        if (search == null || search.isBlank()) {
+            list = firmwareMetadataJpaRepository.findFirmwareMetadataPage(limit, offset);
+            totalCount = firmwareMetadataJpaRepository.countAllFirmwareMetadata();
+        } else {
+            String keyWord = "%" + search + "%";
+            list = firmwareMetadataJpaRepository.searchFirmwareMetadataByVersionOrReleaseNote(limit, offset, keyWord);
+            totalCount = firmwareMetadataJpaRepository.countFirmwareMetadataByVersionOrReleaseNote(keyWord);
+        }
 
         List<FirmwareMetadataResponseDto> content = list.stream()
                 .map(FirmwareMetadataResponseDto::from)


### PR DESCRIPTION
# Changelog

- `/api/firmwares/metadata` API에 search 쿼리 파라미터 추가
- 펌웨어 버전(`version`) 및 릴리즈 노트(`release_note`)를 기준으로 LIKE 검색 가능하도록 기능 구현
- 전체 조회 및 검색 결과에 대해 페이지네이션 정보 함께 반환

# Testing

- `GET /api/firmwares/metadata?search=연두` 요청 시 "연두"이 포함된 version 또는 release_note 레코드만 정상 반환되는지 확인

<img width="716" height="725" alt="image" src="https://github.com/user-attachments/assets/2c243e21-c0bd-4128-829e-97613e41527d" />

- `GET /api/firmwares/metadata` 요청 시 전체 데이터가 정상적으로 페이지네이션되어 반환되는지 확인

<img width="649" height="688" alt="image" src="https://github.com/user-attachments/assets/58a793b9-2ce0-442d-8b57-c1844433b1ab" />

# Ops Impact

N/A

# Version Compatibility

N/A
