### PR TITLE
[Terraform] EMQX를 ECS로 Migration

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,54 @@
+resource "aws_ecs_cluster" "main" {
+  name = "iot-cloud-ota-cluster"
+
+  tags = {
+    Name = "iot-cloud-ota-cluster"
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "iot-cloud-ota-ecs-task-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+# NOTE: ECS 컨테이너에 접속하기 위해서 SSM을 사용합니다.
+resource "aws_iam_policy" "ecs_exec_ssm" {
+  name        = "iot-cloud-ota-ecs-exec-ssm-policy"
+  description = "Policy to allow ECS tasks to use SSM for exec"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_ssm" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = aws_iam_policy.ecs_exec_ssm.arn
+}


### PR DESCRIPTION
# Changelog
- EC2 컨테이너에 생성했던 EMQX 서비스를 ECS에 서비스로 마이그레이션하였습니다.

# Testing
- EMQX 대시보드 접속 테스트
<img width="1707" height="1057" alt="image" src="https://github.com/user-attachments/assets/1faa1216-bd52-420d-b4b3-b26ad3fff626" />

- 아래의 Python 스크립트로 Subscribe 테스트
```python
import paho.mqtt.client as mqtt


def on_connect(client, userdata, flags, rc):
    if rc == 0:
        print("Connected to EMQX with mTLS!")
        client.subscribe("test/topic")
    else:
        print("Failed to connect, return code %d\n", rc)


def on_message(client, userdata, msg):
    print(f"Received message '{msg.payload.decode()}' on topic '{msg.topic}'")


client = mqtt.Client()

client.on_connect = on_connect
client.on_message = on_message

broker_address = "{Broker_Address}"
port = 1883

client.connect(broker_address, port)
client.loop_forever()
```
<img width="1278" height="161" alt="image" src="https://github.com/user-attachments/assets/0324afed-f897-4b01-ad73-2cb2e30aa28c" />

# Ops Impact
N/A

# Version Compatibility
N/A