### PR TITLE
[Backend] 펌웨어 Presigned URL 관련 API 수정

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * Device 관련 요청을 처리하는 REST 컨트롤러 입니다.
+ */
 @RestController
 @RequestMapping("/api/devices")
 @RequiredArgsConstructor

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * 펌웨어 그룹 관련 요청을 처리하는 REST 컨트롤러 입니다.
+ */
 @RestController
 @RequestMapping("/api/divisions")
 @RequiredArgsConstructor

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/FirmwareController.java
@@ -2,7 +2,6 @@ package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.dto.*;
 import com.coffee_is_essential.iot_cloud_ota.service.FirmwareMetadataService;
-import com.coffee_is_essential.iot_cloud_ota.service.S3Service;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,21 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/firmwares")
 public class FirmwareController {
-    private final S3Service s3Service;
     private final FirmwareMetadataService firmwareMetadataService;
-
-    /**
-     * Presigned URL을 발급하여 클라이언트가 인증 없이 S3에 펌웨어 파일을 업로드할 수 있도록 합니다.
-     *
-     * @param requestDto 업로드할 버전 및 파일명을 포함한 요청 DTO
-     * @return 업로드 가능한 S3 Presigne URL 및 실제 저장 경로가 포함된 응답 DTO
-     */
-    @GetMapping("/presigned_upload")
-    public ResponseEntity<UploadPresignedUrlResponseDto> getPresignedUploadUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
-        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUploadUrl(requestDto.version(), requestDto.fileName());
-
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
-    }
 
     /**
      * 펌웨어 메타데이터를 저장합니다.
@@ -73,19 +58,6 @@ public class FirmwareController {
     @GetMapping("/metadata/{id}")
     public ResponseEntity<FirmwareMetadataResponseDto> findById(@PathVariable Long id) {
         FirmwareMetadataResponseDto responseDto = firmwareMetadataService.findById(id);
-
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
-    }
-
-    /**
-     * 지정한 펌웨어 ID에 해당하는 펌웨어의 S3 Presigned 다운로드 URL을 발급합니다.
-     *
-     * @param id 다운로드할 펌웨어 메타데이터의 고유 ID
-     * @return 다운로드 가능한 Presigned URL을 담은 응답 DTO
-     */
-    @GetMapping("/{id}/presigned_download")
-    public ResponseEntity<DownloadPresignedUrlResponseDto> getPresignedDownloadUrl(@PathVariable Long id) {
-        DownloadPresignedUrlResponseDto responseDto = s3Service.getPresignedDownloadUrl(id);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/S3Controller.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/S3Controller.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * AWS S3 관련 요청을 처리하는 REST 컨트롤러 입니다.
+ */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/s3")
@@ -29,14 +32,20 @@ public class S3Controller {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    /**
+     * 주어진 버전과 파일 이름에 해당하는 펌웨어 파일의 S3 Presigned 다운로드 URL을 반환합니다.
+     *
+     * @param version  다운로드할 펌웨어의 버전 (예: "v1.0.0")
+     * @param fileName 다운로드할 펌웨어의 파일 이름 (예: "firmware.bin")
+     * @return 다운로드 가능한 S3 Presigned URL을 담은 응답 DTO
+     */
+    @GetMapping("/presigned_download")
+    public ResponseEntity<DownloadPresignedUrlResponseDto> getPresignedDownloadUrl(
+            @RequestParam(required = true) String version,
+            @RequestParam(required = true) String fileName
+    ) {
+        DownloadPresignedUrlResponseDto responseDto = s3Service.getPresignedDownloadUrl(version, fileName);
 
-//    @GetMapping("/presigned_download")
-//    public ResponseEntity<DownloadPresignedUrlResponseDto> getPresignedDownloadUrl(
-//            @RequestParam(required = true) String version,
-//            @RequestParam(required = true) String fileName
-//    ) {
-//        DownloadPresignedUrlResponseDto responseDto = s3Service.getPresignedDownloadUrl(id);
-//
-//        return new ResponseEntity<>(responseDto, HttpStatus.OK);
-//    }
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/S3Controller.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/S3Controller.java
@@ -1,0 +1,42 @@
+package com.coffee_is_essential.iot_cloud_ota.controller;
+
+import com.coffee_is_essential.iot_cloud_ota.dto.DownloadPresignedUrlResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.PresignedUrlRequestDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.UploadPresignedUrlResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.service.S3Service;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/s3")
+public class S3Controller {
+    private final S3Service s3Service;
+
+    /**
+     * Presigned URL을 발급하여 클라이언트가 인증 없이 S3에 펌웨어 파일을 업로드할 수 있도록 합니다.
+     *
+     * @param requestDto 업로드할 버전 및 파일명을 포함한 요청 DTO
+     * @return 업로드 가능한 S3 Presigned URL 및 실제 저장 경로가 포함된 응답 DTO
+     */
+    @PostMapping("/presigned_upload")
+    public ResponseEntity<UploadPresignedUrlResponseDto> getPresignedUploadUrl(@Valid @RequestBody PresignedUrlRequestDto requestDto) {
+        UploadPresignedUrlResponseDto responseDto = s3Service.getPresignedUploadUrl(requestDto.version(), requestDto.fileName());
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+
+//    @GetMapping("/presigned_download")
+//    public ResponseEntity<DownloadPresignedUrlResponseDto> getPresignedDownloadUrl(
+//            @RequestParam(required = true) String version,
+//            @RequestParam(required = true) String fileName
+//    ) {
+//        DownloadPresignedUrlResponseDto responseDto = s3Service.getPresignedDownloadUrl(id);
+//
+//        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+//    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
@@ -10,7 +10,12 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @Entity
-@Table(name = "firmware_metadata")
+@Table(
+        name = "firmware_metadata",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_filename_version", columnNames = {"fileName", "version"})
+        }
+)
 @NoArgsConstructor
 public class FirmwareMetadata extends BaseEntity {
     @Id

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 펌웨어 메타데이터를 관리하는 JPA 리포지토리 인터페이스입니다.
@@ -88,11 +89,11 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
     long countFirmwareMetadataByVersionOrReleaseNote(@Param("search") String search);
 
     /**
-     * 지정한 버전과 파일 이름을 가진 펌웨어 메타데이터가 존재하는지 확인합니다.
+     * 주어진 버전과 파일 이름에 해당하는 펌웨어 메타데이터를 반환합니다.
      *
-     * @param version  확인할 펌웨어의 버전 (예: "v1.0.0")
-     * @param fileName 확인할 펌웨어의 파일 이름 (예: "firmware.bin")
-     * @return 해당 버전과 파일 이름을 가진 펌웨어 메타데이터가 존재하면 true, 그렇지 않으면 false
+     * @param version  펌에어 버전
+     * @param fileName 펌웨어 파일 이름
+     * @return 존재하면 Optional로 감싼 결과, 존재하지 않으면 Optional.empty()
      */
-    boolean existsByVersionAndFileName(String version, String fileName);
+    Optional<FirmwareMetadata> findByVersionAndFileName(String version, String fileName);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareMetadataJpaRepository.java
@@ -86,4 +86,13 @@ public interface FirmwareMetadataJpaRepository extends JpaRepository<FirmwareMet
             OR release_note LIKE :search
             """, nativeQuery = true)
     long countFirmwareMetadataByVersionOrReleaseNote(@Param("search") String search);
+
+    /**
+     * 지정한 버전과 파일 이름을 가진 펌웨어 메타데이터가 존재하는지 확인합니다.
+     *
+     * @param version  확인할 펌웨어의 버전 (예: "v1.0.0")
+     * @param fileName 확인할 펌웨어의 파일 이름 (예: "firmware.bin")
+     * @return 해당 버전과 파일 이름을 가진 펌웨어 메타데이터가 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByVersionAndFileName(String version, String fileName);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -38,7 +38,7 @@ public class FirmwareMetadataService {
                 requestDto.s3Path()
         );
 
-        if (firmwareMetadataJpaRepository.existsByVersionAndFileName(requestDto.version(), requestDto.fileName())) {
+        if (firmwareMetadataJpaRepository.findByVersionAndFileName(requestDto.version(), requestDto.fileName()).isPresent()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "해당 버전과 파일 이름의 펌웨어가 이미 존재합니다.");
         }
 
@@ -100,8 +100,4 @@ public class FirmwareMetadataService {
 
         return FirmwareMetadataResponseDto.from(findFirmwareMetadata);
     }
-
-//    public FirmwareMetadataResponseDto findBy
-
-
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareMetadataService.java
@@ -24,6 +24,7 @@ public class FirmwareMetadataService {
 
     /**
      * 펌웨어 메타데이터를 저장하고, 저장된 결과를 응답 DTO로 반환합니다.
+     * 동일한 버전과 파일 이름의 펌웨어가 이미 존재할 경우 예외를 발생시킵니다.
      *
      * @param requestDto 저장할 펌웨어 메타데이터 요청 DTO
      * @return 저장된 펌웨어 정보를 담은 응답 DTO
@@ -36,6 +37,10 @@ public class FirmwareMetadataService {
                 requestDto.releaseNote(),
                 requestDto.s3Path()
         );
+
+        if (firmwareMetadataJpaRepository.existsByVersionAndFileName(requestDto.version(), requestDto.fileName())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "해당 버전과 파일 이름의 펌웨어가 이미 존재합니다.");
+        }
 
         FirmwareMetadata savedFirmwareMetadata = firmwareMetadataJpaRepository.save(firmwareMetadata);
 
@@ -95,4 +100,8 @@ public class FirmwareMetadataService {
 
         return FirmwareMetadataResponseDto.from(findFirmwareMetadata);
     }
+
+//    public FirmwareMetadataResponseDto findBy
+
+
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
@@ -10,6 +10,7 @@ import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepos
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.UUID;
@@ -34,6 +35,7 @@ public class S3Service {
      * @param fileName 저장할 파일 이름 (예: "firmware.zip")
      * @return 업로드용 Presigned URL 및 S3 저장 경로가 포함된 DTO
      */
+    @Transactional
     public UploadPresignedUrlResponseDto getPresignedUploadUrl(String version, String fileName) {
         String path = createPath(version, fileName);
         GeneratePresignedUrlRequest generatedPresignedUrlRequest = generatePresignedUploadUrl(bucketName, path);
@@ -58,7 +60,7 @@ public class S3Service {
         return request;
     }
 
-
+//    @Transactional
 //    public DownloadPresignedUrlResponseDto getPresignedDownloadUrl(String version, String fileName) {
 //        FirmwareMetadata metadata = firmwareMetadataJpaRepository.findByVersionAndFileNameOrElseThrow();
 //        GeneratePresignedUrlRequest generatedPresignedUrlRequest = generatePresignedDownloadUrl(bucketName, metadata.getS3Path());

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/S3Service.java
@@ -58,19 +58,14 @@ public class S3Service {
         return request;
     }
 
-    /**
-     * 지정된 펌웨어 ID에 해당하는 S3 객체에 대한 Presigned 다운로드 URL을 생성합니다.
-     *
-     * @param id 펌웨어 메터데이터의 고유 ID
-     * @return 다운로드용 Presigned URL을 포함한 DTO
-     */
-    public DownloadPresignedUrlResponseDto getPresignedDownloadUrl(Long id) {
-        FirmwareMetadata metadata = firmwareMetadataJpaRepository.findByIdOrElseThrow(id);
-        GeneratePresignedUrlRequest generatedPresignedUrlRequest = generatePresignedDownloadUrl(bucketName, metadata.getS3Path());
-        String url = amazonS3.generatePresignedUrl(generatedPresignedUrlRequest).toString();
 
-        return new DownloadPresignedUrlResponseDto(url);
-    }
+//    public DownloadPresignedUrlResponseDto getPresignedDownloadUrl(String version, String fileName) {
+//        FirmwareMetadata metadata = firmwareMetadataJpaRepository.findByVersionAndFileNameOrElseThrow();
+//        GeneratePresignedUrlRequest generatedPresignedUrlRequest = generatePresignedDownloadUrl(bucketName, metadata.getS3Path());
+//        String url = amazonS3.generatePresignedUrl(generatedPresignedUrlRequest).toString();
+//
+//        return new DownloadPresignedUrlResponseDto(url);
+//    }
 
     /**
      * 지정된 S3 경로를 기반으로 다운로드용 Presigned URL 요청 객체를 생성합니다.


### PR DESCRIPTION
# Changelog

- 업로드 Presigned URL 요청 API의 HTTP 메서드를 `GET`에서 `POST`로 변경
  - 변경 전: `GET /api/firmwares/presigned_upload`
  - 변경 후: `POST /api/s3/presigned_upload` (Body에 version, fileName 포함)
- 다운로드 Presigned URL 요청 시 `firmwareId` 기반 조회에서 `version`과 `fileName` 기반 조회로 파라미터 변경
  - 변경 전: `GET /api/firmwares/presigned_download`
  - 변경 후: `GET /api/s3/presigned_download?version=v1.0.0&fileName=firmware.bin`

# Testing

- Postman을 통해 요청 및 응답 확인

# Ops Impact

- 프론트엔드 측 API 요청 방식 변경 필요
  - 업로드는 `POST` 요청 전송으로 수정해야 함
  - 다운로드는 `firmwareId` 대신 version + fileName으로 요청하도록 수정 필요

# Version Compatibility

- 기존 `firmwareId` 기반 다운로드 API와는 호환되지 않음
- 클라이언트 측 수정 이후 정상 동작 가능