### PR TITLE
[Terraform] 사설CA ECS에 배포

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,38 @@
+resource "aws_ecr_repository" "private_ca" {
+  name                 = "private-ca"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-private-ca-ecr-repo"
+    Description = "ECR repository for Private CA in iot-cloud-ota"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "iot_cloud_ota_lifecycle_policy" {
+  repository = aws_ecr_repository.private_ca.name
+
+  policy = <<-EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Expire untagged images older than 30 days",
+          "selection": {
+            "tagStatus": "untagged",
+            "countType": "sinceImagePushed",
+            "countUnit": "days",
+            "countNumber": 30
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+  EOF
+}

--- a/terraform/private_ca.tf
+++ b/terraform/private_ca.tf
@@ -1,0 +1,60 @@
+resource "aws_cloudwatch_log_group" "private_ca" {
+  name              = "/ecs/private-ca"
+  retention_in_days = 14
+
+  tags = {
+    Name        = "iot-cloud-ota-private-ca-log-group"
+    Description = "CloudWatch log group for Private CA in iot-cloud-ota"
+  }
+}
+
+resource "aws_ecs_task_definition" "private_ca" {
+  family                   = "private-ca"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "private-ca"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/private-ca:latest"
+      essential = true
+
+      portMappings = [
+        { containerPort = 80, protocol = "tcp" }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.private_ca.name,
+          "awslogs-region"        = "ap-northeast-2",
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "private_ca" {
+  name                   = "private-ca"
+  cluster                = aws_ecs_cluster.main.id
+  task_definition        = aws_ecs_task_definition.private_ca.arn
+  desired_count          = 1
+  launch_type            = "FARGATE"
+  enable_execute_command = true
+
+  network_configuration {
+    subnets          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+    security_groups  = [aws_security_group.private_ca_sg.id]
+    assign_public_ip = false
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-private-ca-service"
+    Description = "ECS service for Private CA in iot-cloud-ota"
+  }
+}

--- a/terraform/remote-state.tf
+++ b/terraform/remote-state.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_s3_bucket" "remote_state" {
   bucket = "iot-cloud-ota-tf-state-bucket"
 

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -111,3 +111,69 @@ resource "aws_security_group" "emqx_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "private_ca_sg" {
+  name        = "iot-cloud-ota-private-ca-sg"
+  description = "Security group for Private CA service"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.emqx_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "cloudwatch_logs_sg" {
+  name        = "iot-cloud-ota-cloudwatch-logs-sg"
+  description = "Security group for CloudWatch Logs VPC endpoint"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.private_ca_sg.id]
+    description     = "HTTPS access for CloudWatch Logs"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecr_endpoint_sg" {
+  name        = "iot-cloud-ota-ecr-endpoint-sg"
+  description = "Security group for ECR VPC endpoints"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.private_ca_sg.id]
+    description     = "HTTPS access from Private CA service"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "iot-cloud-ota-ecr-endpoint-sg"
+  }
+}


### PR DESCRIPTION
# Changelog
- 사설 CA를 ECS 클러스터에 서비스로 등록하였습니다.
- 사설 CA는 Private Subnet에 있어 직접적으로 인터넷 접근이 불가능합니다. (인터넷 연결을 권장하지 않습니다.) 따라서 Private Subnet에서 외부 AWS 서비스에 접근할 수 있도록 VPC Endpoint를 구성하였습니다.
  - `Private Route Table`: Private Subnet에 있는 서비스들이 Gateway 타입의 VPC Endpoint에 접근할 수 있게 하기 위해 필요
  - `CloudWatch`: ECS 컨테이너 및 서비스 로그를 저장하기 위해 접근 필요
  - `ECR API`, `ECR DKR`, `S3`: ECR에 푸시 되어 있는 이미지를 사용해서 사설 CA를 구성하기 위해 필요

# Testing
- 사설 CA 이미지를 ECR에 푸시하고 해당 이미지를 사용해 `private-ca` 서비스 생성 확인
- CloudWatch 로그 확인
<img width="1438" height="366" alt="image" src="https://github.com/user-attachments/assets/499d90e9-284e-4c4b-9db1-06406abcdab5" />

# Ops Impact
N/A

# Version Compatibility
N/A