### PR TITLE
[FrontEnd] [Terraform] Firmware 등록 API 연결

### DIFF
--- a/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
@@ -46,7 +46,7 @@ export const FirmwareDetail = ({
         />
         <LabeledValue
           label="파일명"
-          value={`${firmware?.version}.ino`}
+          value={firmware?.fileName ?? "없음"}
           size="sm"
         />
         <LabeledValue

--- a/frontend/src/features/firmware_register/api/api.ts
+++ b/frontend/src/features/firmware_register/api/api.ts
@@ -1,0 +1,42 @@
+import { apiClient } from "../../../shared/api/client";
+import {
+  FirmwareMetadataUploadRequest,
+  PresignedUrlResponse,
+} from "../model/types";
+
+/**
+ * 펌웨어를 등록하는 API 서비스입니다.
+ * @namespace firmwareRegisterApiService
+ */
+export const firmwareRegisterApiService = {
+  getPresignedUrl: async (
+    version: string,
+    fileName: string,
+  ): Promise<PresignedUrlResponse> => {
+    const { data } = await apiClient.post<PresignedUrlResponse>(
+      `/api/s3/presigned_upload`,
+      {
+        version,
+        fileName,
+      },
+    );
+    return data;
+  },
+
+  uploadFirmwareViaPresignedUrl: async (
+    url: string,
+    file: File,
+  ): Promise<void> => {
+    await apiClient.put(url, file, {
+      headers: {
+        "Content-Type": file.type,
+      },
+    });
+  },
+
+  uploadFirmwareMetadata: async (
+    firmwareMetadata: FirmwareMetadataUploadRequest,
+  ): Promise<void> => {
+    await apiClient.post<void>(`/api/firmwares/metadata`, firmwareMetadata);
+  },
+};

--- a/frontend/src/features/firmware_register/model/types.ts
+++ b/frontend/src/features/firmware_register/model/types.ts
@@ -1,0 +1,26 @@
+/**
+ * 펌웨어 업로드를 위한 S3 사전 서명 URL 응답 인터페이스입니다.
+ */
+export interface PresignedUrlResponse {
+  url: string;
+  s3Path: string;
+}
+
+/**
+ * 펌웨어 메타데이터 업로드 요청 인터페이스입니다.
+ */
+export interface FirmwareMetadataUploadRequest {
+  version: string;
+  releaseNote: string;
+  fileName: string;
+  s3Path: string;
+}
+
+/**
+ * 펌웨어 등록 폼 데이터 인터페이스입니다.
+ */
+export interface FirmwareRegisterData {
+  version: string;
+  releaseNote: string;
+  file: File | null;
+}

--- a/frontend/src/features/firmware_register/model/types.ts
+++ b/frontend/src/features/firmware_register/model/types.ts
@@ -19,7 +19,7 @@ export interface FirmwareMetadataUploadRequest {
 /**
  * 펌웨어 등록 폼 데이터 인터페이스입니다.
  */
-export interface FirmwareRegisterData {
+export interface FirmwareRegisterFormData {
   version: string;
   releaseNote: string;
   file: File | null;

--- a/frontend/src/features/firmware_register/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware_register/ui/FirmwareRegister.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { Button } from "../../../shared/ui/Button";
 import { FileText, Upload } from "lucide-react";
 import { JSX } from "@emotion/react/jsx-runtime";
-import { FirmwareRegisterData } from "../model/types";
+import { FirmwareRegisterFormData } from "../model/types";
 import { firmwareRegisterApiService } from "../api/api";
 
 /**
@@ -68,7 +68,7 @@ const FilePreview = ({
 export const FirmwareRegisterForm = ({
   onClose,
 }: FirmwareRegisterFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<FirmwareRegisterData>({
+  const [formData, setFormData] = useState<FirmwareRegisterFormData>({
     version: "",
     releaseNote: "",
     file: null,

--- a/frontend/src/features/firmware_register/ui/FirmwareRegister.tsx
+++ b/frontend/src/features/firmware_register/ui/FirmwareRegister.tsx
@@ -2,21 +2,8 @@ import { useRef, useState } from "react";
 import { Button } from "../../../shared/ui/Button";
 import { FileText, Upload } from "lucide-react";
 import { JSX } from "@emotion/react/jsx-runtime";
-import { firmwareApiService } from "../../../entities/firmware/api/firmwareApi";
-import { zipFile } from "../../../shared/api/zip";
-
-/**
- * Interface for FirmwareRegisterForm component props
- * @interface
- * @property {string} version - The firmware version
- * @property {string} releaseNote - The release note for the firmware
- * @property {File | null} file - The firmware file to be uploaded
- */
-export interface FirmwareRegisterFormData {
-  version: string;
-  releaseNote: string;
-  file: File | null;
-}
+import { FirmwareRegisterData } from "../model/types";
+import { firmwareRegisterApiService } from "../api/api";
 
 /**
  * Interface for FirmwareRegisterForm component props
@@ -44,7 +31,8 @@ const FileUploadPlaceHolder = ({
     <Upload size={24} className="mb-2 text-blue-900" />
     <p className="text-sm text-blue-900">펌웨어 파일을 선택하세요.</p>
     <p className="text-xs text-neutral-500">
-      <span className="font-semibold">*.tft</span> 파일 (최대 50MB)
+      {/* TODO: 펌웨어 확장자가 결정되면 아래의 확장자를 업데이트 해야 합니다. */}
+      <span className="font-semibold">*.bin</span> 파일 (최대 100MB)
     </p>
   </div>
 );
@@ -80,7 +68,7 @@ const FilePreview = ({
 export const FirmwareRegisterForm = ({
   onClose,
 }: FirmwareRegisterFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<FirmwareRegisterFormData>({
+  const [formData, setFormData] = useState<FirmwareRegisterData>({
     version: "",
     releaseNote: "",
     file: null,
@@ -98,13 +86,10 @@ export const FirmwareRegisterForm = ({
     if (event.target.files && event.target.files.length > 0) {
       const file = event.target.files[0];
 
-      if (!file.name.endsWith(".tft")) {
-        alert("*.tft 형식의 파일만 업로드 가능합니다.");
-        return;
-      }
+      // TODO: 펌웨어 파일 형식이 정해지고 나면 확장자 체크 추가
 
-      if (file.size > 50 * 1024 * 1024) {
-        alert("파일 크기는 50MB를 초과할 수 없습니다.");
+      if (file.size > 100 * 1024 * 1024) {
+        alert("파일 크기는 100MB를 초과할 수 없습니다.");
         return;
       }
 
@@ -165,24 +150,34 @@ export const FirmwareRegisterForm = ({
       return;
     }
 
-    console.log("펌웨어 등록 요청");
-    console.log("버전:", formData.version);
-    console.log("릴리즈 노트:", formData.releaseNote);
-    console.log("파일:", formData.file);
+    // TODO: 아래의 API 호출을 비동기로 처리하고, 토스트 메시지로 성공/실패 알림을 구현하면 UX가 개선될 것입니다.
+    try {
+      // Step 1: 파일 업로드를 위해 Presigned URL을 가져옵니다.
+      const presignedUrl = await firmwareRegisterApiService.getPresignedUrl(
+        formData.version,
+        formData.file.name,
+      );
 
-    const compressedFile = await zipFile(formData.file);
+      // Step 2: Presigned URL을 사용하여 파일을 S3에 업로드합니다.
+      await firmwareRegisterApiService.uploadFirmwareViaPresignedUrl(
+        presignedUrl.url,
+        formData.file,
+      );
 
-    const success = await firmwareApiService.register(
-      formData.version,
-      formData.releaseNote,
-      compressedFile
-    );
-
-    if (success) {
-      alert("펌웨어 등록이 완료되었습니다.");
+      // Step 3: 펌웨어 메타데이터를 등록합니다.
+      await firmwareRegisterApiService.uploadFirmwareMetadata({
+        version: formData.version,
+        releaseNote: formData.releaseNote,
+        fileName: formData.file.name,
+        s3Path: presignedUrl.s3Path,
+      });
+    } catch (error) {
+      console.error("펌웨어 등록 중 오류 발생:", error);
+      alert("펌웨어 등록에 실패했습니다. 다시 시도해주세요.");
+      return;
+    } finally {
+      // Reset the form after successful submission
       handleReset();
-    } else {
-      alert("펌웨어 등록에 실패했습니다.");
     }
   };
 
@@ -235,7 +230,6 @@ export const FirmwareRegisterForm = ({
             type="file"
             id="firmwareFile"
             className="hidden"
-            accept=".tft"
             onChange={handleFileChange}
           />
 

--- a/frontend/src/pages/FirmwarePage.tsx
+++ b/frontend/src/pages/FirmwarePage.tsx
@@ -8,7 +8,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "../shared/ui/Button";
 import { useState } from "react";
 import ReactModal from "react-modal";
-import { FirmwareRegisterForm } from "../features/firmware/ui/FirmwareRegister";
+import { FirmwareRegisterForm } from "../features/firmware_register/ui/FirmwareRegister";
 
 export const FirmwarePage = () => {
   const {

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -11,6 +11,19 @@ resource "aws_s3_bucket" "firmware_bucket" {
   }
 }
 
+# NOTE: 개발 환경에서의 임시 CORS 설정입니다.
+resource "aws_s3_bucket_cors_configuration" "public_access" {
+  bucket = aws_s3_bucket.firmware_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
 resource "aws_cloudfront_origin_access_control" "firmware_oac" {
   name                              = "firmware-oac"
   description                       = "Origin Access Control for CloudFront to access S3 bucket"


### PR DESCRIPTION
# Changelog
- 펌웨어 등록 기능을 정의하는 `features/firmware_register` 디렉토리를 생성하였습니ㅏㄷ.
- 폼 데이터를 입력받은 후 서버에 펌웨어 파일과 메타데이터를 업로드하는 로직을 구현하였습니다.
  1. 서버에 Presigned URL 발급을 요청합니다.
  2. 발급받은 Presigned URL을 통해 펌웨어 파일을 업로드합니다.
  3. 펌웨어의 메타데이터 등록 요청을 서버에 보냅니다.
- 아직 프론트의 도메인이 고정되지 않았으므로 원활한 개발을 위해 S3 버킷의 CORS를 Public하게 설정하였습니다.

# Testing
`junwoo-25.7.16`이라는 버전으로 `2.out`이라는 파일 테스트 업로드

- 펌웨어 메타데이터 정보 확인
<img width="1127" height="511" alt="image" src="https://github.com/user-attachments/assets/22adeb83-b9c7-4edc-be32-0e9eaab53115" />

- S3 버킷에 업로드 확인
<img width="1118" height="443" alt="image" src="https://github.com/user-attachments/assets/bac1a739-c60d-4981-aa75-80b80d06e6a5" />

# Ops Impact
N/A

# Version Compatibility
N/A