### PR TITLE
[Backend] S3 파일의 SHA-256 해시 계산 메서드 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/component/MockDataInitializer.java
@@ -1,10 +1,8 @@
 //package com.coffee_is_essential.iot_cloud_ota.component;
 //
-//import com.coffee_is_essential.iot_cloud_ota.entity.Device;
 //import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareMetadata;
 //import com.coffee_is_essential.iot_cloud_ota.entity.Division;
 //import com.coffee_is_essential.iot_cloud_ota.entity.Region;
-//import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
 //import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareMetadataJpaRepository;
 //import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
 //import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareMetadata.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * 펌웨어 메타데이터 정보를 저장하는 엔티티 클래스입니다.
- * 버전, 파일명, 릴리즈 노트의 정보를 저장합니다.
+ * 버전, 파일명, 릴리즈 노트의 정보, 체크섬을 저장합니다.
  */
 @Getter
 @Entity
@@ -34,10 +34,20 @@ public class FirmwareMetadata extends BaseEntity {
     @Column(nullable = false)
     private String s3Path;
 
+    private String checksum;
+
     public FirmwareMetadata(String version, String fileName, String releaseNote, String s3Path) {
         this.version = version;
         this.fileName = fileName;
         this.releaseNote = releaseNote;
         this.s3Path = s3Path;
+    }
+
+    public FirmwareMetadata(String version, String fileName, String releaseNote, String s3Path, String checksum) {
+        this.version = version;
+        this.fileName = fileName;
+        this.releaseNote = releaseNote;
+        this.s3Path = s3Path;
+        this.checksum = checksum;
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/exception/GlobalExceptionHandler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.exception;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.coffee_is_essential.iot_cloud_ota.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
# Changelog

- S3 버킷에 저장된 파일의 내용을 스트리밍 방식으로 읽고, 해당 파일의 SHA-256 해시 값을 계산하는 `calculateS3FileHash` 메서드 구현
- 바이트 배열을 16진수 문자열로 변환하는 `bytesToHex` 메서드 구현
- 펌웨어 메타데이터 등록 시, 전달받은 S3 경로의 파일을 읽어 해시 값을 계산한 후 해당 해시를 DB에 함께 저장하도록 로직 추가

# Testing

- S3에 업로드된 파일에 대해 `calculateS3FileHash` 실행하여 SHA-256 해시 값을 정상적으로 반환하는지 확인함
- 테스트 파일 해시를 로컬에서 동일하게 계산한 결과와 비교하여 일치함을 확인함

<img width="1000" height="113" alt="image" src="https://github.com/user-attachments/assets/a267475a-ee0f-4d77-872f-a4bdf69600ee" />

# Ops Impact

N/A

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->

N/A