### PR TITLE
[Cloud/Infra] ECS 서비스 원격 접속을 위한 세션 매니저 구성

### DIFF
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.11.2",
+  "serial": 1,
+  "lineage": "16b4c7d7-c3d0-a2b1-6a70-b6c8b898bbcf",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -157,3 +157,42 @@ resource "aws_vpc_endpoint" "s3" {
     Name = "iot-cloud-ota-s3-endpoint"
   }
 }
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-2.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "iot-cloud-ota-ssm-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-2.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "iot-cloud-ota-ssmmessages-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-2.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "iot-cloud-ota-ec2messages-endpoint"
+  }
+}


### PR DESCRIPTION
# Changelog
- ECS 서비스를 디버깅, 관리하기 위해 원격 접속을 가능하게 하는 SSM 서비스를 활성화하였습니다.
- VPC Endpoint를 추가하여 Private Subnet에 있는 서비스도 접속 가능하도록 하였습니다.

# Testing
- 원격 접속 테스트
```bash
aws ecs execute-command \
--region ap-northeast-2 \
--cluster iot-cloud-ota-cluster \
--task {내 테스크}
--container emqx \
--command "/bin/bash" \
--interactive
```
<img width="738" height="132" alt="image" src="https://github.com/user-attachments/assets/b71710eb-a234-49ca-a649-1a19fa7c789f" />

# Ops Impact
N/A

# Version Compatibility
N/A