### PR TITLE
[Cloud/Infra] Spring Boot 서버를 ECS에 배포

### DIFF
--- a/backend/iot-cloud-ota/Dockerfile
+++ b/backend/iot-cloud-ota/Dockerfile
@@ -1,0 +1,9 @@
+FROM amazoncorretto:17
+
+WORKDIR /app
+
+COPY ./build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/iot-cloud-ota/build.gradle
+++ b/backend/iot-cloud-ota/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'com.amazonaws:aws-java-sdk-cloudfront:1.12.6'
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/config/S3Config.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/config/S3Config.java
@@ -1,54 +1,32 @@
 package com.coffee_is_essential.iot_cloud_ota.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 /**
  * S3Config 클래스는 AWS S3와의 연동을 위한 설정을 구성합니다.
- * AWS 자격 증명 및 AmazonS3 클라이언트를 Bean으로 등록합니다.
+ * AmazonS3 클라이언트를 Bean으로 등록합니다.
  */
 @Configuration
 public class S3Config {
-    @Value("${cloud.aws.credentials.access.key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret.key}")
-    private String secretKey;
 
     @Value("${cloud.aws.region.static}")
     private String region;
 
     /**
-     * AWS 자격 증명을 생성합니다.
-     *
-     * @return BasicAWSCredentials AWS 접근 키와 비밀 키를 포함하는 자격 증명 객체
-     */
-    @Bean
-    @Primary
-    public BasicAWSCredentials awsCredentialsProvider() {
-        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
-
-        return basicAWSCredentials;
-    }
-
-    /**
      * AmazonS3 클라이언트를 생성하여 S3와의 연동을 가능하게 합니다.
+     * Default Credentials Provider Chain(IAM Role)을 사용하여 AWS 자격 증명을 자동으로 처리합니다.
+     * AWS 공식 문서 참조: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
      *
      * @return AmazonS3 AWS S3와 통신할 수 있는 클라이언트
      */
     @Bean
     public AmazonS3 amazonS3() {
-        AmazonS3 s3Builder = AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
-                .build();
-
-        return s3Builder;
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .build();
     }
 }

--- a/backend/iot-cloud-ota/src/main/resources/application.properties
+++ b/backend/iot-cloud-ota/src/main/resources/application.properties
@@ -20,3 +20,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 cloudfront.key.id=${CLOUDFRONT_KEY_ID}
 cloudfront.domain=${CLOUDFRONT_DOMAIN}
 cloudfront.secret=${CLOUDFRONT_SECRET}
+
+management.endpoints.web.exposure.include=health

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,135 @@
+resource "aws_lb" "backend_alb" {
+  name               = "backend-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+  security_groups    = [aws_security_group.backend_alb.id]
+}
+
+resource "aws_lb_target_group" "backend_tg" {
+  name        = "backend-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    protocol = "HTTP"
+    path     = "/actuator/health"
+    port     = "traffic-port"
+    matcher  = "200"
+  }
+}
+
+resource "aws_lb_listener" "backend_listener" {
+  load_balancer_arn = aws_lb.backend_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend_tg.arn
+  }
+}
+
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/ecs/backend"
+  retention_in_days = 14
+
+  tags = {
+    Name        = "iot-cloud-ota-backend-log-group"
+    Description = "CloudWatch log group for Backend in iot-cloud-ota"
+  }
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "backend"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.backend.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/backend:latest"
+      essential = true
+
+      portMappings = [
+        { containerPort = 8080, protocol = "tcp" }
+      ]
+
+      environment = [
+        { name = "AWS_REGION", value = data.aws_region.current.name },
+        { name = "CLOUD_AWS_S3_BUCKET", value = aws_s3_bucket.firmware_bucket.bucket },
+        { name = "CLOUD_AWS_STACK_AUTO", value = tostring(false) },
+        { name = "CLOUD_AWS_REGION_STATIC", value = data.aws_region.current.name },
+        { name = "SPRING_DATASOURCE_URL", value = "jdbc:mysql://${local.db_credentials.host}:${local.db_credentials.port}/${local.db_credentials.dbname}" },
+        { name = "SPRING_DATASOURCE_USERNAME", value = local.db_credentials.username },
+        { name = "SPRING_DATASOURCE_PASSWORD", value = local.db_credentials.password },
+        { name = "CLOUDFRONT_KEY_ID", value = aws_cloudfront_public_key.signing_key.id },
+        { name = "CLOUDFRONT_DOMAIN", value = aws_cloudfront_distribution.firmware_distribution.domain_name },
+        { name = "CLOUDFRONT_SECRET", value = data.aws_secretsmanager_secret.private_signing_key.name },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.backend.name,
+          "awslogs-region"        = data.aws_region.current.name,
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_service_discovery_service" "backend" {
+  name = "backend"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.main.id
+    dns_records {
+      type = "A"
+      ttl  = 10
+    }
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_service" "backend" {
+  name                              = "backend"
+  cluster                           = aws_ecs_cluster.main.id
+  task_definition                   = aws_ecs_task_definition.backend.arn
+  desired_count                     = 1
+  launch_type                       = "FARGATE"
+  enable_execute_command            = true
+  health_check_grace_period_seconds = 200 // NOTE: Spring Boot가 실행되기까지 오래 걸려서 기다리지 않으면 health check에 실패합니다
+
+  network_configuration {
+    subnets          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+    security_groups  = [aws_security_group.backend.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend_tg.arn
+    container_name   = "backend"
+    container_port   = 8080
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.backend.arn
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-backend-service"
+    Description = "Backend service for iot-cloud-ota"
+  }
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -75,3 +75,42 @@ resource "aws_ecr_lifecycle_policy" "emqx" {
     }
   EOF
 }
+
+resource "aws_ecr_repository" "backend" {
+  name                 = "backend"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-backend-ecr-repo"
+    Description = "ECR repository for Backend in iot-cloud-ota"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = <<-EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Expire untagged images older than 30 days",
+          "selection": {
+            "tagStatus": "untagged",
+            "countType": "sinceImagePushed",
+            "countUnit": "days",
+            "countNumber": 30
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+  EOF
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -58,3 +58,50 @@ resource "aws_service_discovery_private_dns_namespace" "main" {
   vpc         = aws_vpc.main.id
   description = "Private DNS namespace for iot-cloud-ota"
 }
+
+resource "aws_iam_role" "backend" {
+  name = "backend-app-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = { Service = "ecs-tasks.amazonaws.com" },
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "backend" {
+  name = "backend-app-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+        ],
+        Resource = [
+          "*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "backend" {
+  role       = aws_iam_role.backend.name
+  policy_arn = aws_iam_policy.backend.arn
+}
+
+resource "aws_iam_role_policy_attachment" "backend_ssm" {
+  role       = aws_iam_role.backend.name
+  policy_arn = aws_iam_policy.ecs_exec_ssm.arn
+}

--- a/terraform/remote-state.tf
+++ b/terraform/remote-state.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 resource "aws_s3_bucket" "remote_state" {
   bucket = "iot-cloud-ota-tf-state-bucket"
 


### PR DESCRIPTION
# Changelog
- 서버 변경사항
  - `IAM Role`을 사용하여 Access Key와 Secret Key를 직접 주입하지 않고 S3에 접근할 수 있도록 `S3Config.java`를 변경하였습니다.
  - Spring Boot의 Dockerfile을 작성하여 이미지를 생성하였습니다.
    - `amazoncorretto:17`을 사용하여 빌드합니다.
  - AWS ALB가 health를 체크할 수 있도록 `actuator`를 사용하여 `/actuator/health`를 health check 엔드포인트로 등록하였습니다.

- 클라우드/인프라 변경사항
  - 백엔드로 트래픽을 전달하는 ALB를 생성하였습니다.
  - ALB의 리스너로 백엔드 서비스를 등록하고, Health Check를 연결하였습니다. (`/actuator/health`)
  - 백엔드 서버가 실행되기 위해 필요한 환경 변수들을 서비스 실행 시 주입하도록 설정하였습니다.
  - 백엔드 서버를 다른 서비스가 접근할 수 있도록 `Service Discovery Service`에 등록하였습니다.
  - ALB는 외부의 트래픽을 허용하고, Spring Boot는 ALB로부터의 트래픽만 허용하도록 Security Group을 구성하였습니다.

# Testing
- 백엔드 서비스의 Task 정상 작동 확인
<img width="1082" height="182" alt="image" src="https://github.com/user-attachments/assets/8da9c0da-3245-4831-956e-690826ce841e" />

- ALB 연동 & Health Check 테스트
<img width="1078" height="153" alt="image" src="https://github.com/user-attachments/assets/1397c76f-3071-4671-8347-d18d1aa9300d" />

- 서버에 Presigned URL 요청 (S3에 접근 가능 여부 테스트)
<img width="996" height="781" alt="image" src="https://github.com/user-attachments/assets/0a713b7e-0a66-4faa-96aa-e6a42f7b7d4f" />

- 서버에 요청 테스트
<img width="1008" height="884" alt="image" src="https://github.com/user-attachments/assets/8d87590e-c872-4de6-a8f6-694557193152" />

# Ops Impact
N/A

# Version Compatibility
N/A