### PR TITLE
[Cloud/Infra] CICD 파이프라인 ECR 푸시 이후 자동 Apply

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -157,15 +157,16 @@ jobs:
           EMQX_IMAGE: ${{ needs.ci-emqx-dev.outputs.tag }}
           PRIVATE_CA_IMAGE: ${{ needs.ci-private-ca-dev.outputs.tag }}
         run: |
-          image_vars=""
+          image_tags=""
           if [ -n "$BACKEND_IMAGE" ]; then
-            image_vars="$image_vars -backend_image $BACKEND_IMAGE"
+            image_tags="$image_tags -backend_image_tag $BACKEND_IMAGE"
           fi
           if [ -n "$EMQX_IMAGE" ]; then
-            image_vars="$image_vars -emqx_image $EMQX_IMAGE"
+            image_tags="$image_tags -emqx_image_tag $EMQX_IMAGE"
           fi
           if [ -n "$PRIVATE_CA_IMAGE" ]; then
-            image_vars="$image_vars -private_ca_image $PRIVATE_CA_IMAGE"
+            image_tags="$image_tags -private_ca_image_tag $PRIVATE_CA_IMAGE"
           fi
 
-          terraform apply -auto-approve $image_vars
+          echo "Applying Terraform with images: $image_tags"
+          terraform apply -auto-approve $image_tags

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -129,6 +129,7 @@ jobs:
 
   terraform-apply:
     needs: [ci-backend-dev, ci-emqx-dev, ci-private-ca-dev]
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -3,7 +3,7 @@ name: Deploy to AWS ECS
 on:
   push:
     branches:
-      - main
+      - implement-auto-deploy-pipeline
 
 env:
   AWS_REGION: ap-northeast-2
@@ -126,3 +126,29 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  terraform-apply:
+    needs: [ci-backend-dev, ci-emqx-dev, ci-private-ca-dev]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -35,6 +35,8 @@ jobs:
     needs: [detect-changes-by-component]
     if: ${{ needs.detect-changes-by-component.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-image.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,6 +69,8 @@ jobs:
     needs: [detect-changes-by-component]
     if: ${{ needs.detect-changes-by-component.outputs.emqx == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-image.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,6 +103,8 @@ jobs:
     needs: [detect-changes-by-component]
     if: ${{ needs.detect-changes-by-component.outputs.private_ca == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-image.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -165,13 +165,13 @@ jobs:
         run: |
           image_tags=""
           if [ -n "$BACKEND_IMAGE" ]; then
-            image_tags="$image_tags -backend_image_tag $BACKEND_IMAGE"
+            image_tags="$image_tags -var backend_image_tag=$BACKEND_IMAGE"
           fi
           if [ -n "$EMQX_IMAGE" ]; then
-            image_tags="$image_tags -emqx_image_tag $EMQX_IMAGE"
+            image_tags="$image_tags -var emqx_image_tag=$EMQX_IMAGE"
           fi
           if [ -n "$PRIVATE_CA_IMAGE" ]; then
-            image_tags="$image_tags -private_ca_image_tag $PRIVATE_CA_IMAGE"
+            image_tags="$image_tags -var private_ca_image_tag=$PRIVATE_CA_IMAGE"
           fi
 
           echo "Applying Terraform with images: $image_tags"

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -152,4 +152,20 @@ jobs:
         run: terraform init
 
       - name: Terraform Apply
-        run: terraform apply -auto-approve
+        env:
+          BACKEND_IMAGE: ${{ needs.ci-backend-dev.outputs.image }}
+          EMQX_IMAGE: ${{ needs.ci-emqx-dev.outputs.image }}
+          PRIVATE_CA_IMAGE: ${{ needs.ci-private-ca-dev.outputs.image }}
+        run: |
+          image_vars =""
+          if [ -n "$BACKEND_IMAGE" ]; then
+            image_vars="$image_vars -backend_image $BACKEND_IMAGE"
+          fi
+          if [ -n "$EMQX_IMAGE" ]; then
+            image_vars="$image_vars -emqx_image $EMQX_IMAGE"
+          fi
+          if [ -n "$PRIVATE_CA_IMAGE" ]; then
+            image_vars="$image_vars -private_ca_image $PRIVATE_CA_IMAGE"
+          fi
+
+          terraform apply -auto-approve $image_vars

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -61,7 +61,7 @@ jobs:
             -f backend/iot-cloud-ota/Dockerfile backend/iot-cloud-ota
           docker push $ECR_REGISTRY/$ECR_BACKEND_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_BACKEND_REPOSITORY:latest
-          echo "image=$ECR_REGISTRY/$ECR_BACKEND_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   ci-emqx-dev:
     needs: [detect-changes-by-component]
@@ -93,7 +93,7 @@ jobs:
             -f emqx/Dockerfile emqx
           docker push $ECR_REGISTRY/$ECR_EMQX_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_EMQX_REPOSITORY:latest
-          echo "image=$ECR_REGISTRY/$ECR_EMQX_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   ci-private-ca-dev:
     needs: [detect-changes-by-component]
@@ -125,7 +125,7 @@ jobs:
             -f private_ca/Dockerfile private_ca
           docker push $ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:latest
-          echo "image=$ECR_REGISTRY/$ECR_EMQX_PRIVATE_CA_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   terraform-apply:
     needs: [ci-backend-dev, ci-emqx-dev, ci-private-ca-dev]
@@ -153,11 +153,11 @@ jobs:
 
       - name: Terraform Apply
         env:
-          BACKEND_IMAGE: ${{ needs.ci-backend-dev.outputs.image }}
-          EMQX_IMAGE: ${{ needs.ci-emqx-dev.outputs.image }}
-          PRIVATE_CA_IMAGE: ${{ needs.ci-private-ca-dev.outputs.image }}
+          BACKEND_IMAGE: ${{ needs.ci-backend-dev.outputs.tag }}
+          EMQX_IMAGE: ${{ needs.ci-emqx-dev.outputs.tag }}
+          PRIVATE_CA_IMAGE: ${{ needs.ci-private-ca-dev.outputs.tag }}
         run: |
-          image_vars =""
+          image_vars=""
           if [ -n "$BACKEND_IMAGE" ]; then
             image_vars="$image_vars -backend_image $BACKEND_IMAGE"
           fi

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -12,5 +12,4 @@ RUN mkdir -p /opt/emqx/etc/certs && chown -R emqx:emqx /opt/emqx/etc/certs
 
 USER emqx
 
-ENTRYPOINT ["/entrypoint.sh"]
-
+ENTRYPOINT ["/entrypoint.sh"] 

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -13,3 +13,4 @@ RUN mkdir -p /opt/emqx/etc/certs && chown -R emqx:emqx /opt/emqx/etc/certs
 USER emqx
 
 ENTRYPOINT ["/entrypoint.sh"]
+

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -13,3 +13,4 @@ RUN mkdir -p /opt/emqx/etc/certs && chown -R emqx:emqx /opt/emqx/etc/certs
 USER emqx
 
 ENTRYPOINT ["/entrypoint.sh"] 
+

--- a/emqx/Dockerfile
+++ b/emqx/Dockerfile
@@ -13,4 +13,3 @@ RUN mkdir -p /opt/emqx/etc/certs && chown -R emqx:emqx /opt/emqx/etc/certs
 USER emqx
 
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "backend" {
   container_definitions = jsonencode([
     {
       name      = "backend"
-      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/backend:latest"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/backend:${var.backend_image_tag}"
       essential = true
 
       portMappings = [

--- a/terraform/emqx.tf
+++ b/terraform/emqx.tf
@@ -75,7 +75,7 @@ resource "aws_ecs_task_definition" "emqx" {
   container_definitions = jsonencode([
     {
       name      = "emqx"
-      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/emqx:latest"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/emqx:${var.emqx_image_tag}"
       essential = true
 
       portMappings = [

--- a/terraform/private_ca.tf
+++ b/terraform/private_ca.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_task_definition" "private_ca" {
   container_definitions = jsonencode([
     {
       name      = "private-ca"
-      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/private-ca:latest"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/private-ca:${var.private_ca_image_tag}"
       essential = true
 
       portMappings = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "backend_image_tag" {
+  description = "The tag of the backend image to use."
+  type        = string
+  default     = "latest"
+}
+
+variable "emqx_image_tag" {
+  description = "The tag of the frontend image to use."
+  type        = string
+  default     = "latest"
+}
+
+variable "private_ca_image_tag" {
+  description = "The tag of the private CA image to use."
+  type        = string
+  default     = "latest"
+}


### PR DESCRIPTION
# Changelog
- `terraform/` 프로젝트에서 `backend`, `emqx`, `private_ca`의 이미지 태그를 variable로 받을 수 있도록 변경하였습니다.
- CI/CD 파이프라인에서 이미지가 변경된 경우, `terraform-apply` JOB에 전달하고, 새로운 이미지를 가지고 실행될 수 있도록 변경하였습니다.

# Testing
<img width="1089" height="248" alt="image" src="https://github.com/user-attachments/assets/cadaf4eb-b589-4253-af9e-53b794ed9aaa" />

# Ops Impact
N/A

# Version Compatibility
N/A