### PR TITLE
[Cloud/Infra] 백엔드 서버 Dockerfile에 Gradle Build 추가

### DIFF
--- a/backend/iot-cloud-ota/Dockerfile
+++ b/backend/iot-cloud-ota/Dockerfile
@@ -1,9 +1,10 @@
-FROM amazoncorretto:17
-
+FROM gradle:8.14.3-jdk17-alpine AS build
 WORKDIR /app
+COPY . /app
+RUN gradle clean bootJar --no-daemon
 
-COPY ./build/libs/*.jar app.jar
-
+FROM amazoncorretto:17
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
-
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
# Changelog
- 기존에 수동으로 Gradle build하던 것을 Dockerfile에서 빌드를 포함해서 수행하도록 변경하였습니다.

# Testing
<img width="1726" height="435" alt="image" src="https://github.com/user-attachments/assets/ad109fb2-eb95-43e9-a0b3-d90442840c5d" />

# Ops Impact
N/A

# Version Compatibility
N/A