### PR TITLE
[Cloud/Infra] 개발을 위해 EMQX 1883 포트 임시 활성화

### DIFF
--- a/terraform/emqx.tf
+++ b/terraform/emqx.tf
@@ -5,7 +5,21 @@ resource "aws_lb" "emqx_nlb" {
   subnets            = [aws_subnet.public_a.id, aws_subnet.public_b.id]
 }
 
-resource "aws_lb_target_group" "nlb_tg" {
+// NOTE: 개발 편의를 위해 1883 포트를 임시로 열고, 배포 전 닫습니다.
+resource "aws_lb_target_group" "nlb_tg_mqtt" {
+  name        = "emqx-mqtt-tg"
+  port        = 1883
+  protocol    = "TCP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    protocol = "TCP"
+    port     = "1883"
+  }
+}
+
+resource "aws_lb_target_group" "nlb_tg_mqtt_tls" {
   name        = "emqx-tg"
   port        = 8883
   protocol    = "TCP"
@@ -31,14 +45,25 @@ resource "aws_lb_target_group" "nlb_tg_dashboard" {
   }
 }
 
-resource "aws_lb_listener" "nlb_listener" {
+resource "aws_lb_listener" "nlb_listener_mqtt" {
+  load_balancer_arn = aws_lb.emqx_nlb.arn
+  port              = 1883
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt.arn
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener_mqtt_tls" {
   load_balancer_arn = aws_lb.emqx_nlb.arn
   port              = 8883
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.nlb_tg.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls.arn
   }
 }
 
@@ -49,7 +74,7 @@ resource "aws_lb_listener" "nlb_listener_dashboard" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.nlb_tg_dashboard.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls_dashboard.arn
   }
 }
 
@@ -132,13 +157,19 @@ resource "aws_ecs_service" "emqx" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.nlb_tg.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt.arn
+    container_name   = "emqx"
+    container_port   = 1883
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls.arn
     container_name   = "emqx"
     container_port   = 8883
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.nlb_tg_dashboard.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls_dashboard.arn
     container_name   = "emqx"
     container_port   = 18083
   }

--- a/terraform/emqx.tf
+++ b/terraform/emqx.tf
@@ -74,7 +74,7 @@ resource "aws_lb_listener" "nlb_listener_dashboard" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls_dashboard.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_dashboard.arn
   }
 }
 
@@ -169,7 +169,7 @@ resource "aws_ecs_service" "emqx" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.nlb_tg_mqtt_tls_dashboard.arn
+    target_group_arn = aws_lb_target_group.nlb_tg_dashboard.arn
     container_name   = "emqx"
     container_port   = 18083
   }


### PR DESCRIPTION
# Changelog
- MQTT 핸들러와 기기의 MQTT 클라이언트가 현재 개발 진행중이고 인증서를 갱신하는 로직이 개발 진행중인 관계로, 1883 포트를 활성화하여 MQTT without TLS를 가능하게 합니다.

# Testing
- MQTT Subscribe 테스트
```
import paho.mqtt.client as mqtt


def on_connect(client, userdata, flags, rc):
    if rc == 0:
        print("Connected to EMQX with mTLS!")
        client.subscribe("test/topic")
    else:
        print("Failed to connect, return code %d\n", rc)


def on_message(client, userdata, msg):
    print(f"Received message '{msg.payload.decode()}' on topic '{msg.topic}'")


client = mqtt.Client()

client.on_connect = on_connect
client.on_message = on_message

broker_address = <우리 브로커 주소>
port = 1883

client.connect(broker_address, port)
client.loop_forever()
```
<img width="857" height="104" alt="image" src="https://github.com/user-attachments/assets/e32ae3e2-68f5-473d-b44f-b1802062b23e" />

# Ops Impact
N/A

# Version Compatibility
N/A