### PR TITLE
[Cloud/Infra] Private Subnet이 AWS Public Service에 접근하기 위한 NAT 구성

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role" "backend" {
   })
 }
 
-resource "aws_iam_policy" "backend" {
+resource "aws_iam_policy" "s3" {
   name = "backend-app-policy"
 
   policy = jsonencode({
@@ -96,12 +96,61 @@ resource "aws_iam_policy" "backend" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "backend" {
+resource "aws_iam_policy" "cloudfront_signing" {
+  name = "cloudfront-signing-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudfront:GetPublicKey",
+          "cloudfront:ListPublicKeys",
+          "cloudfront:GetDistribution",
+          "cloudfront:ListDistributions",
+          "cloudfront:CreateInvalidation",
+        ],
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "secrets_manager_read" {
+  name = "secrets-manager-read-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "backend_s3" {
   role       = aws_iam_role.backend.name
-  policy_arn = aws_iam_policy.backend.arn
+  policy_arn = aws_iam_policy.s3.arn
 }
 
 resource "aws_iam_role_policy_attachment" "backend_ssm" {
   role       = aws_iam_role.backend.name
   policy_arn = aws_iam_policy.ecs_exec_ssm.arn
+}
+
+resource "aws_iam_role_policy_attachment" "backend_cloudfront_signing" {
+  role       = aws_iam_role.backend.name
+  policy_arn = aws_iam_policy.cloudfront_signing.arn
+}
+
+resource "aws_iam_role_policy_attachment" "backend_secrets_manager_read" {
+  role       = aws_iam_role.backend.name
+  policy_arn = aws_iam_policy.secrets_manager_read.arn
 }

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "mysql_sg" {
       aws_security_group.bastion_sg.id,
       aws_security_group.backend.id,
     ]
-    description = "MySQL access from public subnets"
+    description = "MySQL access from trusted security groups"
   }
 
   egress {
@@ -118,84 +118,6 @@ resource "aws_security_group" "private_ca_sg" {
     to_port         = 80
     protocol        = "tcp"
     security_groups = [aws_security_group.emqx_sg.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_security_group" "cloudwatch_logs_sg" {
-  name        = "iot-cloud-ota-cloudwatch-logs-sg"
-  description = "Security group for CloudWatch Logs VPC endpoint"
-  vpc_id      = aws_vpc.main.id
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    security_groups = [
-      aws_security_group.private_ca_sg.id,
-      aws_security_group.emqx_sg.id,
-      aws_security_group.backend.id,
-    ]
-    description = "HTTPS access for CloudWatch Logs"
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_security_group" "ecr_endpoint_sg" {
-  name        = "iot-cloud-ota-ecr-endpoint-sg"
-  description = "Security group for ECR VPC endpoints"
-  vpc_id      = aws_vpc.main.id
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    security_groups = [
-      aws_security_group.private_ca_sg.id,
-      aws_security_group.emqx_sg.id,
-      aws_security_group.backend.id,
-    ]
-    description = "HTTPS access from Private CA service"
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "iot-cloud-ota-ecr-endpoint-sg"
-  }
-}
-
-resource "aws_security_group" "ssm_endpoint_sg" {
-  name        = "iot-cloud-ota-ssm-endpoint-sg"
-  description = "Security group for SSM VPC endpoints"
-  vpc_id      = aws_vpc.main.id
-
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    security_groups = [
-      aws_security_group.private_ca_sg.id,
-      aws_security_group.emqx_sg.id,
-      aws_security_group.backend.id,
-    ]
   }
 
   egress {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -64,6 +64,32 @@ resource "aws_internet_gateway" "main" {
   }
 }
 
+resource "aws_eip" "nat_a" {
+  domain = "vpc"
+}
+
+resource "aws_eip" "nat_b" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "nat_a" {
+  allocation_id = aws_eip.nat_a.id
+  subnet_id     = aws_subnet.public_a.id
+
+  tags = {
+    Name = "iot-cloud-ota-nat-a"
+  }
+}
+
+resource "aws_nat_gateway" "nat_b" {
+  allocation_id = aws_eip.nat_b.id
+  subnet_id     = aws_subnet.public_b.id
+
+  tags = {
+    Name = "iot-cloud-ota-nat-b"
+  }
+}
+
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
@@ -78,6 +104,34 @@ resource "aws_route_table" "public" {
   }
 }
 
+resource "aws_route_table" "private_a" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_a.id
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-private-route-table-a"
+    Description = "Route table for private subnet a in iot-cloud-ota"
+  }
+}
+
+resource "aws_route_table" "private_b" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_b.id
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-private-route-table-b"
+    Description = "Route table for private subnet b in iot-cloud-ota"
+  }
+}
+
 resource "aws_route_table_association" "public_a" {
   subnet_id      = aws_subnet.public_a.id
   route_table_id = aws_route_table.public.id
@@ -88,111 +142,12 @@ resource "aws_route_table_association" "public_b" {
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_route_table" "private" {
-  vpc_id = aws_vpc.main.id
-
-  tags = {
-    Name        = "iot-cloud-ota-private-route-table-a"
-    Description = "Route table for private subnets in iot-cloud-ota"
-  }
-}
-
 resource "aws_route_table_association" "private_a" {
   subnet_id      = aws_subnet.private_a.id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private_a.id
 }
 
 resource "aws_route_table_association" "private_b" {
   subnet_id      = aws_subnet.private_b.id
-  route_table_id = aws_route_table.private.id
-}
-
-resource "aws_vpc_endpoint" "cloudwatch_logs" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.logs"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.cloudwatch_logs_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "cloudwatch-logs-endpoint"
-  }
-}
-
-resource "aws_vpc_endpoint" "ecr_api" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.ecr.api"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.ecr_endpoint_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "iot-cloud-ota-ecr-api-endpoint"
-  }
-}
-
-resource "aws_vpc_endpoint" "ecr_dkr" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.ecr.dkr"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.ecr_endpoint_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "iot-cloud-ota-ecr-dkr-endpoint"
-  }
-}
-
-# NOTE: S3는 ECR이 이미지 레이어를 저장하는 데 사용되므로, Private Subnet에 있는 ECS 서비스가 이미지를 가져오기 위해 S3에 접근해야 합니다.
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = aws_vpc.main.id
-  service_name      = "com.amazonaws.ap-northeast-2.s3"
-  vpc_endpoint_type = "Gateway"
-  route_table_ids   = [aws_route_table.private.id]
-
-  tags = {
-    Name = "iot-cloud-ota-s3-endpoint"
-  }
-}
-
-resource "aws_vpc_endpoint" "ssm" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.ssm"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "iot-cloud-ota-ssm-endpoint"
-  }
-}
-
-resource "aws_vpc_endpoint" "ssmmessages" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.ssmmessages"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "iot-cloud-ota-ssmmessages-endpoint"
-  }
-}
-
-resource "aws_vpc_endpoint" "ec2messages" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.ap-northeast-2.ec2messages"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.private_a.id, aws_subnet.private_b.id]
-  security_group_ids  = [aws_security_group.ssm_endpoint_sg.id]
-  private_dns_enabled = true
-
-  tags = {
-    Name = "iot-cloud-ota-ec2messages-endpoint"
-  }
+  route_table_id = aws_route_table.private_b.id
 }


### PR DESCRIPTION
# Changelog
- 현재 모든 서비스는 Private Subnet에 배치되어 있고, AWS의 퍼블릭 서비스(S3, CloudWatch 등)에 접근하기 위해서 `VPC Endpoint`를 사용해왔습니다. 하지만 CloudFront에 접근하여 Signed URL을 발급받아야 하는데 **CloudFront는 VPC Endpoint를 지원하지 않는 문제**가 발생하였습니다.
- 따라서 VPC Endpoint로 접근하는 방법 대신 **NAT 게이트웨이를 설정하여 Private Subnet이 인터넷으로 접근 가능하도록 변경**하였습니다.

# Testing
- Private Subnet의 Spring Boot가 CloudFront에 정상적으로 접근할 수 있는지 검증
<img width="999" height="931" alt="image" src="https://github.com/user-attachments/assets/505144b7-d8fa-4b4a-9451-fff730f44e3d" />

# Ops Impact
N/A

# Version Compatibility
N/A