### PR TITLE
[Frontend] 기기 관리 페이지 초기 설정

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -5,6 +5,7 @@ import { FirmwarePage } from "../pages/FirmwarePage";
 import { AdsPage } from "../pages/AdsPage";
 import { MonitoringPage } from "../pages/MonitoringPage";
 import { FirmwareDetailPage } from "../pages/FirmwareDetailPage";
+import { DevicePage } from "../pages/DevicePage";
 
 export const Router = createBrowserRouter([
   {
@@ -16,6 +17,7 @@ export const Router = createBrowserRouter([
       { path: "dashboard", element: <DashboardPage /> },
       { path: "firmware", element: <FirmwarePage /> },
       { path: "firmware/:id", element: <FirmwareDetailPage /> },
+      { path: "device", element: <DevicePage /> },
       { path: "ads", element: <AdsPage /> },
       { path: "monitoring", element: <MonitoringPage /> },
     ],

--- a/frontend/src/pages/DevicePage.tsx
+++ b/frontend/src/pages/DevicePage.tsx
@@ -1,0 +1,15 @@
+import { MainTile } from "../widgets/layout/ui/MainTile";
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
+
+export const DevicePage = () => {
+  return (
+    <div className="flex flex-col">
+      <div className="mb-8">
+        <TitleTile title="기기 관리" description="기기 목록 및 상태 관리" />
+      </div>
+      <div>
+        <MainTile title="등록된 기기 목록" />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/widgets/sidebar/model/useNavigation.tsx
+++ b/frontend/src/widgets/sidebar/model/useNavigation.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useMemo } from "react";
 import {
+  Bot,
   ChartColumn,
   LayoutDashboard,
   Megaphone,
@@ -29,6 +30,12 @@ export const useNavigation = () => {
         path: "/firmware",
       },
       {
+        id: "device",
+        icon: <Bot />,
+        name: "기기 관리",
+        path: "/device",
+      },
+      {
         id: "ads",
         icon: <Megaphone />,
         name: "광고 관리",
@@ -41,7 +48,7 @@ export const useNavigation = () => {
         path: "/monitoring",
       },
     ],
-    []
+    [],
   );
 
   return {


### PR DESCRIPTION
# Changelog
- 기기 목록과 정보를 보여주는 `<DevicePage/>` 컴포넌트를 생성하였습니다.
- Router에 기기 관리 페이지를 추가하였습니다.

# Testing
<img width="1417" height="700" alt="image" src="https://github.com/user-attachments/assets/b052c276-f2d5-4051-9564-96430fd541a9" />

# Ops Impact
N/A

# Version Compatibility
N/A