### PR TITLE
[Cloud/Infra] 시계열 데이터베이스 QuestDB 구성

### DIFF
--- a/terraform/quest_db.tf
+++ b/terraform/quest_db.tf
@@ -1,0 +1,58 @@
+resource "aws_ebs_volume" "questdb_volume" {
+  availability_zone = aws_subnet.private_a.availability_zone
+  size              = 20
+  type              = "gp3"
+
+  tags = {
+    Name = "questdb-volume"
+  }
+}
+
+resource "aws_instance" "questdb" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t3.small"
+  subnet_id                   = aws_subnet.private_a.id
+  vpc_security_group_ids      = [aws_security_group.questdb.id]
+  associate_public_ip_address = false
+  key_name                    = data.aws_key_pair.ssh_key.key_name
+
+  user_data = <<-EOF
+    #!/bin/bash
+    mkfs -t ext4 /dev/nvme1n1
+    mkdir -p /data
+    UUID=$(blkid -s UUID -o value /dev/nvme1n1)
+    sed -i "\|/data|d" /etc/fstab
+    echo "UUID=$UUID /data ext4 defaults,nofail 0 2" | tee -a /etc/fstab
+
+    mount -a
+
+    chown ubuntu:ubuntu /data
+    chmod 755 /data
+
+    apt-get update -y
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable"
+    apt-get update -y
+    apt-get install -y docker-ce docker-ce-cli containerd.io
+    usermod -aG docker ubuntu
+    systemctl enable --now docker
+
+    docker run -d --name questdb \
+      -p 9000:9000 -p 9009:9009 -p 8812:8812 -p 9003:9003 \
+      -v /data:/var/lib/questdb \
+      questdb/questdb:latest
+  EOF
+
+  tags = {
+    Name = "questdb-instance"
+  }
+}
+
+resource "aws_volume_attachment" "questdb_attachment" {
+  device_name = "/dev/xvdb"
+  volume_id   = aws_ebs_volume.questdb_volume.id
+  instance_id = aws_instance.questdb.id
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -215,3 +215,51 @@ resource "aws_security_group" "grafana" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "questdb" {
+  name        = "iot-cloud-ota-questdb-sg"
+  description = "Security group for Quest DB service"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    from_port       = 8812
+    to_port         = 8812
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    from_port       = 9000
+    to_port         = 9000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    from_port       = 9003
+    to_port         = 9003
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    from_port       = 9009
+    to_port         = 9009
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
# Changelog
- `AWS TimeStream`이 신규 생성이 불가능해지게 되었고, `AWS Timestream for InfluxDB`는 최소 월 10만원 이상의 비용이 나올 것으로 예상됩니다. 따라서 **오픈소스 시계열 데이터베이스를 EC2에 구성**할 필요가 생겼습니다.
- 경량이고, 속도가 매우 빠른 것이 검증된 `QuestDB`를 EC2인스턴스에 구성하였습니다.
- Private Subnet에 배치하고, Bastion 서버가 SSH 연결로 접속 가능하도록 하여 로컬에서 SSH 터널링이 가능하도록 구성하였습니다. (개발의 편의를 위해서)
- `EBS` 를 연결하여 인스턴스가 재시작되더라도 데이터를 유지할 수 있도록 구성하였습니다.


# Testing
- SSH 터널링 이후 9000번 포트에 접속한 결과 화면
<img width="1710" height="1059" alt="image" src="https://github.com/user-attachments/assets/1e14c776-40cd-4cfd-a5d6-1fc2221fca10" />

- Python 라이브러리를 사용해 정상적으로 데이터가 쓰여지는지 확인
```
from questdb.ingress import Sender, TimestampNanos
import numpy as np

conf = f'http::addr=localhost:19000;'
with Sender.from_conf(conf) as sender:
    sender.row(
        'trades',
        symbols={
            'symbol': 'ETH-USD',
            'side': 'sell'
        },
        columns={
            'price': 2615.54,
            'amount': 0.00044,

            # NumPy float64 arrays are supported from v3.0.0rc1 onwards.
            # Note that requires QuestDB server >= 9.0.0 for array support
            'ord_book_bids': np.array([2615.54, 2618.63]),
        },
        at=TimestampNanos.now())
    sender.flush()
```
<img width="1708" height="1056" alt="image" src="https://github.com/user-attachments/assets/67e6b916-9d07-4a5d-a8f7-efe91be67b3b" />

# Ops Impact
N/A

# Version Compatibility
N/A