### PR TITLE
[Terraform] NAT Gateway를 NAT Instance로 대체

### DIFF
--- a/terraform/nat_instance.tf
+++ b/terraform/nat_instance.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "nat" {
     Description = "NAT instance for iot-cloud-ota"
   }
 
-  user_data = <<-EOF
+  user_data = <<-EOT
     #!/bin/bash
     
     sudo yum install iptables-services -y
@@ -45,5 +45,5 @@ resource "aws_instance" "nat" {
     sudo /sbin/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
     sudo /sbin/iptables -F FORWARD
     sudo service iptables save
-  EOF
+  EOT
 }

--- a/terraform/nat_instance.tf
+++ b/terraform/nat_instance.tf
@@ -1,0 +1,49 @@
+data "aws_ami" "nat" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+}
+
+resource "aws_instance" "nat" {
+  ami           = data.aws_ami.nat.id
+  instance_type = "t3.nano"
+  subnet_id     = aws_subnet.public_a.id
+
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.nat.id]
+
+  // NAT로 동작하기 위해 Source/Destination Check를 비활성화 합니다.
+  source_dest_check = false
+
+  tags = {
+    Name        = "iot-cloud-ota-nat-instance"
+    Description = "NAT instance for iot-cloud-ota"
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    
+    sudo yum install iptables-services -y
+    sudo systemctl enable iptables
+    sudo systemctl start iptables
+
+    # Enable IP forwarding
+    touch /etc/sysctl.d/custom-ip-forwarding.conf
+    echo "net.ipv4.ip_forward = 1" | sudo tee -a /etc/sysctl.d/custom-ip-forwarding.conf
+    sudo sysctl -p /etc/sysctl.d/custom-ip-forwarding.conf
+
+    # Configure iptables for NAT
+    sudo /sbin/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+    sudo /sbin/iptables -F FORWARD
+    sudo service iptables save
+  EOF
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -263,3 +263,36 @@ resource "aws_security_group" "questdb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "nat" {
+  name        = "iot-cloud-ota-nat-instance-sg"
+  description = "Security group for NAT instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["10.0.0.0/16"] # 현재 내 VPC의 CIDR 블록
+    security_groups = [aws_security_group.backend.id]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-nat-instance-sg"
+    Description = "Security group for NAT instance in iot-cloud-ota"
+  }
+}


### PR DESCRIPTION
# Changelog
- 현재 NAT Gateway로 인해 너무 많은 비용이 발생하고 있습니다. 트래픽은 없지만, 켜놓는 것만으로도 한 달에 $150 달러 정도의 비용이 발생할 것으로 예상됩니다.
- 개발하는 동안 **비용을 줄이기 위해 NAT Gateway를 주석 처리**하고, **NAT Instance를 구성**하였습니다.
  - NAT Instance의 인스턴스 타입은 `t3.nano`로 설정하였습니다.
  - NAT Instance가 NAT로 동작하기 위해 `source_dest_check = false`로 설정하고, `user_data`에 NAT 관련 설정을 추가하였습니다. ([이 링크 참고](https://docs.aws.amazon.com/ko_kr/vpc/latest/userguide/work-with-nat-instances.html#create-nat-ami))

# Testing
- Backend 서비스를 재배포하여 ECR, Cloud Watch 등에 정상적으로 접근하는지 확인
<img width="1379" height="89" alt="image" src="https://github.com/user-attachments/assets/ca78c982-b6be-4139-b1cd-8b26955f207a" />

- Backend에서 CloudFront의 Signed URL을 정상적으로 발급할 수 있는지 확인

# Ops Impact
N/A

# Version Compatibility
N/A