### PR TITLE
[Mqtt Handler] 펌웨어 다운로드 취소 기능 개발

### DIFF
--- a/mqtt-handler/types/firmware.go
+++ b/mqtt-handler/types/firmware.go
@@ -6,6 +6,12 @@ type FirmwareDeployRequest struct {
 	Devices   []DeviceIds `json:"devices"`
 }
 
+type FirmwareDeployCancelRequest struct {
+	Devices   []DeviceIds `json:"devices"`
+	CommandID string      `json:"commandId"`
+	Reason    string      `json:"reason"`
+}
+
 type FileInfo struct {
 	DeploymentId string `json:"deploymentId"`
 	Version      string `json:"version"`
@@ -33,6 +39,11 @@ type FirmwareDownloadCommand struct {
 	Size      int64  `json:"size"`
 	Timeout   string `json:"timeout"`
 	Timestamp string `json:"timestamp"`
+}
+
+type FirmwareDownloadCancelCommand struct {
+	CommandID string `json:"command_id"`
+	Reason    string `json:"reason"`
 }
 
 type FirmwareDownloadRequestAck struct {


### PR DESCRIPTION
# Changelog

- 펌웨어 다운로드 취소 API 추가: `POST /api/firmwares/deployment/cancel` 엔드포인트 구현
  - 요청 바디 검증(command_id, reason, devices 필수) 및 실패 응답 처리
- MQTT 취소 Publish 로직 추가: `MQTTClient.PublishDownloadCancelRequest(*FirmwareDeployCancelRequest)`
  - 디바이스별 고루틴 병렬 Publish (sync.WaitGroup 사용)

# Testing

- Postman으로 API 호출하여 MQTT 메시지 전송 확인
- 파이썬 스크립트로 EMQX 브로커 연결 및 메시지 수신 확인
- QuestDB 테이블에 이벤트가 정상 저장되는지 확인

<img width="1400" height="149" alt="image" src="https://github.com/user-attachments/assets/1fcebdb5-bca2-4fb3-a62d-ac81257a8a0b" />

<img width="1173" height="28" alt="image" src="https://github.com/user-attachments/assets/ce3207b4-7327-4795-9ff0-63c1009900a3" />

# Ops Impact

- N/A

# Version Compatibility

- N/A
