### PR TITLE
[Frontend] 펌웨어 배포 API 요청 함수 구현

### DIFF
--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -44,13 +44,9 @@ export const requestFirmwareDeploy = async (
   groups: Group[],
   devices: Device[],
 ): Promise<void> => {
-  const regionIds = regions.map((region) => region.regionId);
-  const groupIds = groups.map((group) => group.groupId);
-  const deviceIds = devices.map((device) => device.deviceId);
-
   await apiClient.post(`/api/firmwares/metadata/${firmwareId}/deployment`, {
-    regionIds: regionIds,
-    groupIds: groupIds,
-    deviceIds: deviceIds,
+    regionIds: regions.map((region) => region.regionId),
+    groupIds: groups.map((group) => group.groupId),
+    deviceIds: devices.map((device) => device.deviceId),
   });
 };

--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -4,6 +4,7 @@ import { Group } from "../../../entities/group/model/types";
 import { Device } from "../../../entities/device/model/types";
 import { GroupApiService } from "../../../entities/group/api/api";
 import { deviceApiService } from "../../../entities/device/api/api";
+import { apiClient } from "../../../shared/api/client";
 
 /**
  * Fetches all available regions from the API
@@ -27,4 +28,29 @@ export const fetchGroups = async (): Promise<Group[]> => {
  */
 export const fetchDevices = async (): Promise<Device[]> => {
   return await deviceApiService.getDevices();
+};
+
+/**
+ * Requests a firmware deployment to specified regions, groups, and devices
+ * @param {number} firmwareId - The ID of the firmware to deploy
+ * @param {Region[]} regions - Array of regions to deploy the firmware to
+ * @param {Group[]} groups - Array of groups to deploy the firmware to
+ * @param {Device[]} devices - Array of devices to deploy the firmware to
+ * @returns {Promise<void>} Promise that resolves when the deployment request is complete
+ */
+export const requestFirmwareDeploy = async (
+  firmwareId: number,
+  regions: Region[],
+  groups: Group[],
+  devices: Device[],
+): Promise<void> => {
+  const regionIds = regions.map((region) => region.regionId);
+  const groupIds = groups.map((group) => group.groupId);
+  const deviceIds = devices.map((device) => device.deviceId);
+
+  await apiClient.post(`/api/firmwares/metadata/${firmwareId}/deployment`, {
+    regionIds: regionIds,
+    groupIds: groupIds,
+    deviceIds: deviceIds,
+  });
 };

--- a/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
+++ b/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
@@ -2,7 +2,12 @@ import { JSX, useEffect, useState } from "react";
 import { DeployCategory } from "../model/types";
 import { Region } from "../../../entities/region/model/types";
 import { Device } from "../../../entities/device/model/types";
-import { fetchDevices, fetchGroups, fetchRegions } from "../api/api";
+import {
+  fetchDevices,
+  fetchGroups,
+  fetchRegions,
+  requestFirmwareDeploy,
+} from "../api/api";
 import { RegionTable } from "./RegionTable";
 import { Group } from "../../../entities/group/model/types";
 import { GroupTable } from "./GroupTable";
@@ -185,9 +190,33 @@ export const FirmwareDeploy = ({
   };
 
   const handleDeploy = async () => {
-    // TODO: Implement the actual deployment API request
-    alert("배포 요청");
-    return;
+    if (
+      selectedRegions.length === 0 &&
+      selectedGroups.length === 0 &&
+      selectedDevices.length === 0
+    ) {
+      setError("배포할 대상을 하나 이상 선택해주세요.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await requestFirmwareDeploy(
+        firmware.id,
+        selectedRegions,
+        selectedGroups,
+        selectedDevices,
+      );
+      onClose();
+    } catch (error) {
+      setError(
+        `배포 요청 중 오류가 발생했습니다: ${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const summary = getSelectedSummary();

--- a/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
+++ b/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
@@ -65,6 +65,12 @@ export const FirmwareDeploy = ({
   const [error, setError] = useState<string | null>(null);
 
   const handleCategoryChange = (category: DeployCategory) => {
+    // Reset selections when changing category
+    // This ensures that previous selections do not carry over
+    setSelectedRegions([]);
+    setSelectedGroups([]);
+    setSelectedDevices([]);
+
     setDeployCategory(category);
   };
 


### PR DESCRIPTION
# Changelog
- 펌웨어 배포 요청을 클릭하면 실행되는 `handleDeploy()` 함수를 작성하였습니다.
  - 먼저 리전, 그룹, 디바이스 중 하나도 선택되지 않으면 유효하지 않은 요청으로 간주합니다.
  - `requestFirmwareDeploy()` 함수를 호출합니다.
  - `requestFirmwareDeploy()`함수는 펌웨어 배포를 요청하는 API를 호출합니다.

# Testing
- 프론트에서 `bartooler-002(id:2)`, `bartooler-003(id:3)`에 대해 배포 요청
https://github.com/user-attachments/assets/7eb301ab-9f2a-4c48-9111-a6ac0344eca2

- 서버 로그 출력
<img width="1299" height="149" alt="image" src="https://github.com/user-attachments/assets/fb715e01-bb47-4420-986d-2372ffec653c" />

# Ops Impact
N/A

# Version Compatibility
N/A