### PR TITLE
[Frontend] Child Navigation 추가 및 스타일 개선

### DIFF
--- a/frontend/src/widgets/sidebar/model/useNavigation.tsx
+++ b/frontend/src/widgets/sidebar/model/useNavigation.tsx
@@ -9,9 +9,10 @@ import {
 
 export interface NavigationItemType {
   id: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   name: string;
   path: string;
+  children?: NavigationItemType[];
 }
 
 export const useNavigation = () => {

--- a/frontend/src/widgets/sidebar/ui/NavigationItem.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationItem.tsx
@@ -1,27 +1,78 @@
-import { ReactNode } from "react";
+import { JSX, ReactNode } from "react";
 
-interface NavigationItemProps {
-  icon: ReactNode;
+/**
+ * 네비게이션 아이템 컴포넌트 props 인터페이스
+ * @interface
+ * @param {ReactNode} icon - 아이콘 컴포넌트 (선택 사항)
+ * @param {string} name - 네비게이션 아이템 이름
+ * @param {boolean} isActive - 현재 활성화된 아이템인지 여부
+ * @param {boolean} isParent - 부모 아이템인지 여부 (자식 아이템이 있는 경우)
+ * @param {boolean} isChild - 자식 아이템인지 여부
+ * @param {Function} onClick - 아이템 클릭 시 호출되는 콜백 함수
+ */
+export interface NavigationItemProps {
+  icon?: ReactNode;
   name: string;
   isActive?: boolean;
+  isParent?: boolean;
+  isChild?: boolean;
   onClick?: () => void;
 }
 
+/**
+ * 네비게이션 아이템 컴포넌트입니다.
+ * 사이드바 메뉴 & 드롭다운 메뉴에서 각 페이지를 표시하는 데 사용됩니다.
+ * @param {NavigationItemProps} props - 컴포넌트 props
+ * @returns {JSX.Element} 네비게이션 아이템 컴포넌트
+ */
 export const NavigationItem = ({
   icon,
   name,
   isActive = false,
+  isParent = false,
+  isChild = false,
   onClick = () => {},
-}: NavigationItemProps) => {
+}: NavigationItemProps): JSX.Element => {
+  const baseClasses =
+    "group relative flex items-center transition-all duration-200 ease-in-out rounded-lg";
+
+  const sizeClasses = isChild ? "px-3 py-2 text-sm" : "px-4 py-3";
+
+  const colorClasses = isActive
+    ? isChild
+      ? "bg-slate-700/60 text-slate-200 shadow-sm"
+      : "bg-slate-700/50 text-slate-100 shadow-lg shadow-slate-900/20"
+    : isChild
+      ? "text-gray-400 hover:text-gray-200 hover:bg-gray-800/50"
+      : "text-gray-300 hover:text-white hover:bg-gray-800/50";
+
   return (
     <div
-      className={`flex items-center gap-3 text-gray-300 transition-colors cursor-pointer hover:text-white ${
-        isActive ? "text-white" : ""
-      }`}
+      className={`${baseClasses} ${sizeClasses} ${colorClasses} cursor-pointer`}
       onClick={onClick}
     >
-      {icon}
-      <p>{name}</p>
+      {/* 활성화 여부 표시 */}
+      {isActive && !isChild && (
+        <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-slate-400 rounded-r-full" />
+      )}
+
+      {icon && (
+        <div
+          className={`flex-shrink-0 transition-transform duration-200 ${isActive ? "scale-110" : "group-hover:scale-105"} ${isChild ? "mr-2" : "mr-3"}`}
+        >
+          {icon}
+        </div>
+      )}
+
+      <span
+        className={`font-medium ${isChild ? "text-sm" : "text-base"} ${isActive && !isChild ? "font-semibold" : ""}`}
+      >
+        {name}
+      </span>
+
+      {isActive && isParent && (
+        <div className="absolute inset-0 bg-slate-800/30 rounded-lg -z-10" />
+      )}
     </div>
   );
 };

--- a/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
+++ b/frontend/src/widgets/sidebar/ui/NavigationMenu.tsx
@@ -8,23 +8,46 @@ interface NavigationMenuProps {
 
 export const NavigationMenu = ({ onMenuClick }: NavigationMenuProps) => {
   const { navigationItems } = useNavigation();
-
-  // Calculate current path, used to determine if NavigationItem is active
   const location = useLocation();
   const currentPath = location.pathname;
 
   return (
-    <div className="flex flex-col items-start gap-12 pl-16">
-      {navigationItems.map((item) => (
-        <Link to={item.path} key={item.id} onClick={onMenuClick}>
-          <NavigationItem
-            key={item.id}
-            icon={item.icon}
-            name={item.name}
-            isActive={currentPath.startsWith(item.path)}
-          />
-        </Link>
-      ))}
-    </div>
+    <nav className="flex flex-col gap-2 p-6">
+      {navigationItems.map((item) => {
+        const isParentActive = currentPath.startsWith(item.path);
+
+        return (
+          <div key={item.id} className="mb-2">
+            <Link to={item.path} onClick={onMenuClick} className="block">
+              <NavigationItem
+                icon={item.icon}
+                name={item.name}
+                isActive={currentPath.startsWith(item.path)}
+                isParent={!!item.children}
+              />
+            </Link>
+
+            {isParentActive && item.children && (
+              <div className="ml-3 mt-4 space-y-2 border-l-2 border-gray-700/50 pl-4">
+                {item.children.map((child) => (
+                  <Link
+                    to={child.path}
+                    key={child.id}
+                    onClick={onMenuClick}
+                    className="block"
+                  >
+                    <NavigationItem
+                      name={child.name}
+                      isActive={currentPath === child.path}
+                      isChild={true}
+                    />
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </nav>
   );
 };


### PR DESCRIPTION
# Changelog
- 네비게이션 바의 아이템에 부모 네비게이션 - 자식 네비게이션 관계를 설정할 수 있도록 변경하였습니다.
  - 예시 (펌웨어 관리 > 펌웨어 목록, 펌웨어 관리 > 펌웨어 배포 현황 등)
```typescript
const navigationItems = useMemo<NavigationItemType[]>(
  () => [
    {
      id: "firmware",
      icon: <SquareTerminal />,
      name: "펌웨어 관리",
      path: "/firmware",
      children: [ // 추가
          {
            id: "firmware-list",
            name: "펌웨어 목록",
            path: "/firmware/list",
          },
          {
            id: "firmware-deployment",
            name: "배포 관리",
            path: "/firmware/deployment",
          },
        ],
```
- 현재 접속해있는 페이지를 더 잘 구분할 수 있도록 스타일을 개선하였습니다.
  - 현재 활성화된 페이지 왼쪽에 활성 상태 바를 추가하였습니다.
  - 현재 활성화된 페이지의 백그라운드 색을 설정하였습니다.

# Testing
https://github.com/user-attachments/assets/ab4ab559-2958-4f72-afd2-1872c394a75c

# Ops Impact
N/A

# Version Compatibility
N/A