### PR TITLE
[Frontend] 배포 진행상황 가로 폭 고정

### DIFF
--- a/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
@@ -59,7 +59,7 @@ const DeploymentProgressBar = ({
 
   return (
     <div className="flex items-center gap-3">
-      <div className="w-full bg-gray-200 rounded-full h-3 flex overflow-hidden">
+      <div className="w-3/4 bg-gray-200 rounded-full h-3 flex overflow-hidden">
         {/* 성공 (초록색) */}
         <div
           className="h-full bg-green-500"


### PR DESCRIPTION
# Changelog
- 배포 진행상황 바 너비를 w-3/4 로 고정하여 기기 개수에 상관없이 동일한 너비를 갖도록 수정하였습니다.

# Testing
- 변경전
<img width="1387" height="769" alt="image" src="https://github.com/user-attachments/assets/fa25b387-dd62-4043-a19c-60d05ac5a01d" />

- 변경후
<img width="1388" height="770" alt="image" src="https://github.com/user-attachments/assets/0e446a08-af63-4cbb-ae77-103b8c939c40" />

# Ops Impact
N/A

# Version Compatibility
N/A