### PR TITLE
[Frontend] 배포 세부 정보 페이지 구현

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -7,6 +7,7 @@ import { MonitoringPage } from "../pages/MonitoringPage";
 import { FirmwareDetailPage } from "../pages/FirmwareDetailPage";
 import { DevicePage } from "../pages/DevicePage";
 import { FirmwareDeploymentPage } from "../pages/FirmwareDeploymentPage";
+import { FirmwareDeploymentDetailPage } from "../pages/FirmwareDeploymentDetailPage";
 
 export const Router = createBrowserRouter([
   {
@@ -20,6 +21,10 @@ export const Router = createBrowserRouter([
       { path: "firmware/list", element: <FirmwareListPage /> },
       { path: "firmware/:id", element: <FirmwareDetailPage /> },
       { path: "firmware/deployment", element: <FirmwareDeploymentPage /> },
+      {
+        path: "firmware/deployment/:id",
+        element: <FirmwareDeploymentDetailPage />,
+      },
       { path: "device", element: <DevicePage /> },
       { path: "ads", element: <AdsPage /> },
       { path: "monitoring", element: <MonitoringPage /> },

--- a/frontend/src/entities/firmware_deployment/api/useFirmwareDeploymentDetail.tsx
+++ b/frontend/src/entities/firmware_deployment/api/useFirmwareDeploymentDetail.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { FirmwareDeploymentDetails } from "../model/types";
+import { firmwareDeploymentApiService } from "./api";
+
+/**
+ * useFirmwareDeploymentDetail 훅의 반환 값 인터페이스
+ */
+export interface FirmwareDeploymentDetailHookResult {
+  deployment: FirmwareDeploymentDetails | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * 특정 ID의 펌웨어 배포 상세 정보를 가져오는 커스텀 React 훅
+ *
+ * 이 훅은 API 호출을 처리하여 특정 펌웨어 배포의 상세 정보를 가져오고,
+ * 로딩 상태를 관리하며, 데이터 가져오기 중 발생할 수 있는 오류를 처리합니다.
+ *
+ * @param {number | null} id - 가져올 펌웨어 배포의 ID. null인 경우 오류 상태가 설정됩니다.
+ * @returns {FirmwareDeploymentDetailHookResult} 펌웨어 배포 데이터, 로딩 상태, 오류 메시지를 포함하는 객체
+ */
+export const useFirmwareDeploymentDetail = (
+  id: number | null,
+): FirmwareDeploymentDetailHookResult => {
+  const [deployment, setDeployment] =
+    useState<FirmwareDeploymentDetails | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchDeployment = async () => {
+      if (!id) {
+        setError("배포 ID가 유효하지 않습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const result =
+          await firmwareDeploymentApiService.getFirmwareDeploymentDetails(id);
+        if (!result) {
+          setError("배포를 찾을 수 없습니다.");
+          setIsLoading(false);
+          return;
+        }
+        setDeployment(result);
+      } catch (error) {
+        setError("배포를 가져오는 중 오류가 발생했습니다.");
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDeployment();
+  }, [id]);
+
+  return { deployment, isLoading, error };
+};

--- a/frontend/src/entities/firmware_deployment/api/useFirmwareDeploymentDetail.tsx
+++ b/frontend/src/entities/firmware_deployment/api/useFirmwareDeploymentDetail.tsx
@@ -41,7 +41,6 @@ export const useFirmwareDeploymentDetail = (
           await firmwareDeploymentApiService.getFirmwareDeploymentDetails(id);
         if (!result) {
           setError("배포를 찾을 수 없습니다.");
-          setIsLoading(false);
           return;
         }
         setDeployment(result);

--- a/frontend/src/entities/firmware_deployment/model/types.ts
+++ b/frontend/src/entities/firmware_deployment/model/types.ts
@@ -54,7 +54,7 @@ export interface FirmwareDeploymentDetailsResponse
  */
 export type FirmwareDeploymentDeviceStatus = {
   id: number;
-  status: "SUCCESS" | "IN_PROGRESS" | "FAILED";
+  status: "SUCCESS" | "IN_PROGRESS" | "FAILED" | "TIMEOUT";
   progress: number;
   lastUpdatedAt: Date;
 };

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
@@ -1,12 +1,22 @@
+import { JSX } from "react";
 import { FirmwareDeploymentDeviceStatus } from "../model/types";
 
+/**
+ * 디바이스별 배포 상태에 따른 배지 컴포넌트 Props 인터페이스
+ */
 export interface DeploymentDeviceStatusBadgeProps {
   status: FirmwareDeploymentDeviceStatus["status"];
 }
 
+/**
+ * 디바이스별 배포 상태에 따른 배지 컴포넌트
+ *
+ * @param {DeploymentDeviceStatusBadgeProps} props - 컴포넌트 Props
+ * @returns {JSX.Element} 상태에 따른 스타일과 라벨이 적용된 배지 컴포넌트
+ */
 export const DeploymentDeviceStatusBadge = ({
   status,
-}: DeploymentDeviceStatusBadgeProps) => {
+}: DeploymentDeviceStatusBadgeProps): JSX.Element => {
   let bgColor = "";
   let textColor = "";
   let label = "";

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
@@ -1,0 +1,48 @@
+import { FirmwareDeploymentDeviceStatus } from "../model/types";
+
+export interface DeploymentDeviceStatusBadgeProps {
+  status: FirmwareDeploymentDeviceStatus["status"];
+}
+
+export const DeploymentDeviceStatusBadge = ({
+  status,
+}: DeploymentDeviceStatusBadgeProps) => {
+  let bgColor = "";
+  let textColor = "";
+  let label = "";
+
+  switch (status) {
+    case "SUCCESS":
+      bgColor = "bg-green-100";
+      textColor = "text-green-800";
+      label = "완료";
+      break;
+    case "IN_PROGRESS":
+      bgColor = "bg-blue-100";
+      textColor = "text-blue-800";
+      label = "진행 중";
+      break;
+    case "FAILED":
+      bgColor = "bg-red-100";
+      textColor = "text-red-800";
+      label = "실패";
+      break;
+    case "TIMEOUT":
+      bgColor = "bg-gray-100";
+      textColor = "text-gray-800";
+      label = "시간 초과";
+      break;
+    default:
+      bgColor = "bg-gray-100";
+      textColor = "text-gray-800";
+      label = "알 수 없음";
+  }
+
+  return (
+    <span
+      className={`px-2 py-1 rounded-full text-xs font-medium ${bgColor} ${textColor}`}
+    >
+      {label}
+    </span>
+  );
+};

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
@@ -5,7 +5,7 @@ import { JSX } from "react";
  */
 export interface ProgressBarProps {
   total: number;
-  succeded: number;
+  succeeded: number;
   failed: number;
   inProgress: number;
 }
@@ -18,15 +18,15 @@ export interface ProgressBarProps {
  */
 export const DeploymentProgressBar = ({
   total,
-  succeded,
+  succeeded,
   failed,
   inProgress,
 }: ProgressBarProps): JSX.Element => {
-  const successWidth = total ? (succeded / total) * 100 : 0;
+  const successWidth = total ? (succeeded / total) * 100 : 0;
   const failedWidth = total ? (failed / total) * 100 : 0;
   const inProgressWidth = total ? (inProgress / total) * 100 : 0;
 
-  const overallProgress = total > 0 ? Math.round((succeded / total) * 100) : 0;
+  const overallProgress = total > 0 ? Math.round((succeeded / total) * 100) : 0;
 
   return (
     <div className="flex items-center gap-3">
@@ -34,7 +34,7 @@ export const DeploymentProgressBar = ({
         <div
           className="h-full bg-green-500 float-left"
           style={{ width: `${successWidth}%` }}
-          title={`성공: ${succeded}`}
+          title={`성공: ${succeeded}`}
         ></div>
         <div
           className="h-full bg-blue-500 float-left"

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
@@ -1,0 +1,44 @@
+export interface ProgressBarProps {
+  total: number;
+  succeded: number;
+  failed: number;
+  inProgress: number;
+}
+
+export const DeploymentProgressBar = ({
+  total,
+  succeded,
+  failed,
+  inProgress,
+}: ProgressBarProps) => {
+  const successWidth = total ? (succeded / total) * 100 : 0;
+  const failedWidth = total ? (failed / total) * 100 : 0;
+  const inProgressWidth = total ? (inProgress / total) * 100 : 0;
+
+  const overallProgress = total > 0 ? Math.round((succeded / total) * 100) : 0;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-green-500 float-left"
+          style={{ width: `${successWidth}%` }}
+          title={`성공: ${succeded}`}
+        ></div>
+        <div
+          className="h-full bg-blue-500 float-left"
+          style={{ width: `${inProgressWidth}%` }}
+          title={`진행 중: ${inProgress}`}
+        ></div>
+        <div
+          className="h-full bg-red-500 float-left"
+          style={{ width: `${failedWidth}%` }}
+          title={`실패: ${failed}`}
+        ></div>
+      </div>
+      <span className="text-sm font-medium text-neutral-600 min-w-max">
+        {overallProgress}%
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentProgressBar.tsx
@@ -1,3 +1,8 @@
+import { JSX } from "react";
+
+/**
+ * 배포 진행 상황을 바 형태로 시각화하는 컴포넌트의 Props 인터페이스
+ */
 export interface ProgressBarProps {
   total: number;
   succeded: number;
@@ -5,12 +10,18 @@ export interface ProgressBarProps {
   inProgress: number;
 }
 
+/**
+ * 배포 진행 상황을 바 형태로 시각화하는 컴포넌트
+ *
+ * @param {ProgressBarProps} props - 컴포넌트 Props
+ * @returns {JSX.Element} 배포 진행 상황을 나타내는 프로그레스 바 컴포넌트
+ */
 export const DeploymentProgressBar = ({
   total,
   succeded,
   failed,
   inProgress,
-}: ProgressBarProps) => {
+}: ProgressBarProps): JSX.Element => {
   const successWidth = total ? (succeded / total) * 100 : 0;
   const failedWidth = total ? (failed / total) * 100 : 0;
   const inProgressWidth = total ? (inProgress / total) * 100 : 0;

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentStatusBadge.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentStatusBadge.tsx
@@ -1,12 +1,22 @@
+import { JSX } from "react";
 import { FirmwareDeployment } from "../model/types";
 
+/**
+ * 배포 상태에 따른 배지 컴포넌트 Props 인터페이스
+ */
 export interface DeploymentStatusBadgeProps {
   status: FirmwareDeployment["status"];
 }
 
+/**
+ * 배포 상태에 따른 배지 컴포넌트
+ *
+ * @param {DeploymentStatusBadgeProps} props - 컴포넌트 Props
+ * @returns {JSX.Element} 상태에 따른 스타일과 라벨이 적용된 배지 컴포넌트
+ */
 export const DeploymentStatusBadge = ({
   status,
-}: DeploymentStatusBadgeProps) => {
+}: DeploymentStatusBadgeProps): JSX.Element => {
   let bgColor = "";
   let textColor = "";
   let label = "";

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentStatusBadge.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentStatusBadge.tsx
@@ -1,0 +1,43 @@
+import { FirmwareDeployment } from "../model/types";
+
+export interface DeploymentStatusBadgeProps {
+  status: FirmwareDeployment["status"];
+}
+
+export const DeploymentStatusBadge = ({
+  status,
+}: DeploymentStatusBadgeProps) => {
+  let bgColor = "";
+  let textColor = "";
+  let label = "";
+
+  switch (status) {
+    case "PENDING":
+      bgColor = "bg-yellow-100";
+      textColor = "text-yellow-800";
+      label = "대기 중";
+      break;
+    case "IN_PROGRESS":
+      bgColor = "bg-blue-100";
+      textColor = "text-blue-800";
+      label = "진행 중";
+      break;
+    case "COMPLETED":
+      bgColor = "bg-green-100";
+      textColor = "text-green-800";
+      label = "완료";
+      break;
+    default:
+      bgColor = "bg-gray-100";
+      textColor = "text-gray-800";
+      label = "알 수 없음";
+  }
+
+  return (
+    <span
+      className={`px-2 py-1 rounded-full text-xs font-medium ${bgColor} ${textColor}`}
+    >
+      {label}
+    </span>
+  );
+};

--- a/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
@@ -1,89 +1,67 @@
 import { Link } from "react-router";
 import { FirmwareDeployment } from "../model/types";
+import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
+import { DeploymentProgressBar } from "./DeploymentProgressBar";
 
 /**
- * 배포 상태에 따른 배지 컴포넌트
- * 배포 진행 상태에 따라 다른 색상과 텍스트를 표시합니다.
- * - PENDING: 회색 배경, "대기 중" 텍스트
- * - IN_PROGRESS: 파란색 배경, "진행 중" 텍스트
- * - COMPLETED: 초록색 배경, "완료" 텍스트
+ * 개별 배포 카드 컴포넌트
  */
-const StatusBadge = ({ status }: { status: FirmwareDeployment["status"] }) => {
-  const statusStyles = {
-    COMPLETED: "bg-green-100 text-green-800",
-    IN_PROGRESS: "bg-blue-100 text-blue-800",
-    PENDING: "bg-gray-100 text-gray-800",
-  };
-  const statusText = {
-    COMPLETED: "완료",
-    IN_PROGRESS: "진행 중",
-    PENDING: "대기 중",
-  };
-
+const DeploymentCard = ({ deployment }: { deployment: FirmwareDeployment }) => {
   return (
-    <span
-      className={`px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap ${statusStyles[status]}`}
+    <Link
+      to={`/firmware/deployment/${deployment.id}`}
+      className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
     >
-      {statusText[status]}
-    </span>
-  );
-};
+      {/* 헤더: 배포 ID와 상태 */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold text-neutral-800">
+            배포 #{deployment.id}
+          </span>
+          <DeploymentStatusBadge status={deployment.status} />
+        </div>
+        <span className="text-sm text-neutral-500">
+          {deployment.startedAt.toLocaleString()}
+        </span>
+      </div>
 
-/**
- * 배포 진행률을 시각적으로 표시하는 컴포넌트
- * 성공, 실패, 진행 중인 디바이스 수에 따라 색상으로 구분된 Progress Bar를 렌더링합니다.
- * @param total - 총 디바이스 수
- * @param success - 성공한 디바이스 수
- * @param failed - 실패한 디바이스 수
- * @param inProgress - 진행 중인 디바이스 수
- */
-const DeploymentProgressBar = ({
-  total,
-  success,
-  failed,
-  inProgress,
-}: {
-  total: number;
-  success: number;
-  failed: number;
-  inProgress: number;
-}) => {
-  if (total === 0) {
-    return <div className="text-sm text-neutral-500">-</div>;
-  }
+      {/* 배포 정보와 진행률을 한 줄로 */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-6">
+          <div>
+            <span className="text-xs text-neutral-500">타입: </span>
+            <span className="text-sm text-neutral-800">
+              {deployment.target.type}
+            </span>
+          </div>
+          <div>
+            <span className="text-xs text-neutral-500">대상: </span>
+            <span className="text-sm text-neutral-800">
+              {deployment.target.name}
+            </span>
+          </div>
+        </div>
 
-  // 각 상태의 비율 계산
-  const successPercentage = (success / total) * 100;
-  const failedPercentage = (failed / total) * 100;
-  const inProgressPercentage = (inProgress / total) * 100;
+        {/* 상태 요약을 오른쪽에 간단히 */}
+        <div className="flex items-center gap-3 text-xs">
+          <span className="text-green-600">성공 {deployment.successCount}</span>
+          <span className="text-blue-600">
+            진행 {deployment.inProgressCount}
+          </span>
+          <span className="text-red-600">실패 {deployment.failedCount}</span>
+        </div>
+      </div>
 
-  return (
-    <div className="flex items-center gap-3">
-      <div className="w-3/4 bg-gray-200 rounded-full h-3 flex overflow-hidden">
-        {/* 성공 (초록색) */}
-        <div
-          className="h-full bg-green-500"
-          style={{ width: `${successPercentage}%` }}
-          title={`성공: ${success}개`}
-        />
-        {/* 실패 (빨간색) */}
-        <div
-          className="h-full bg-red-500"
-          style={{ width: `${failedPercentage}%` }}
-          title={`실패: ${failed}개`}
-        />
-        {/* 진행 중 (파란색) */}
-        <div
-          className="h-full bg-blue-400"
-          style={{ width: `${inProgressPercentage}%` }}
-          title={`진행 중: ${inProgress}개`}
+      {/* 진행률 */}
+      <div>
+        <DeploymentProgressBar
+          total={deployment.totalDevices}
+          succeded={deployment.successCount}
+          failed={deployment.failedCount}
+          inProgress={deployment.inProgressCount}
         />
       </div>
-      {/* 진행률 텍스트 */}
-      <span className="text-sm font-medium text-neutral-600 min-w-max">
-        {success} / {total}
-      </span>
-    </div>
+    </Link>
   );
 };
 
@@ -98,11 +76,6 @@ export interface FirmwareDeploymentListProps {
 
 /**
  * 펌웨어 배포 목록 컴포넌트
- * 배포 ID, 타입, 대상, 시작 시간, 진행률, 상태 등의 정보를 테이블 형식으로 표시합니다.
- * @param deployments - 펌웨어 배포 목록
- * @param isLoading - 데이터 로딩 상태
- * @param error - 에러 메시지
- * @returns JSX.Element
  */
 export const FirmwareDeploymentList = ({
   deployments,
@@ -112,68 +85,24 @@ export const FirmwareDeploymentList = ({
   if (isLoading) {
     return <div className="flex justify-center py-8">로딩 중...</div>;
   }
+
   if (error) {
     return <div className="flex justify-center py-8 text-red-500">{error}</div>;
   }
 
-  return (
-    <div className="border border-gray-200 rounded-md">
-      <div className="w-full table border-collapse">
-        {/* --- 테이블 헤더 --- */}
-        <div className="text-sm font-medium text-neutral-600 bg-gray-50 table-header-group">
-          <div className="table-row">
-            <div className="p-3 table-cell">배포 ID</div>
-            <div className="p-3 table-cell">배포 타입</div>
-            <div className="p-3 table-cell">대상</div>
-            <div className="p-3 table-cell">시작 시간</div>
-            <div className="p-3 table-cell w-1/3">진행률</div>
-            <div className="p-3 text-center table-cell">상태</div>
-          </div>
-        </div>
-
-        {/* --- 테이블 본문 --- */}
-        <div className="table-row-group">
-          {deployments.length === 0 ? (
-            <div className="table-row">
-              <div className="p-8 text-center text-neutral-500">
-                배포 이력이 없습니다.
-              </div>
-            </div>
-          ) : (
-            deployments.map((deployment) => (
-              <Link
-                to={`/firmware/deployment/${deployment.id}`}
-                key={deployment.id}
-                className="table-row transition-colors border-b border-gray-100 last:border-b-0 hover:bg-gray-50"
-              >
-                <div className="p-4 text-sm font-semibold text-neutral-800 table-cell align-middle">
-                  #{deployment.id}
-                </div>
-                <div className="p-4 text-sm text-neutral-600 table-cell align-middle">
-                  {deployment.target.type}
-                </div>
-                <div className="p-4 text-sm text-neutral-600 table-cell align-middle">
-                  {deployment.target.name}
-                </div>
-                <div className="p-4 text-sm text-neutral-600 table-cell align-middle whitespace-nowrap">
-                  {deployment.startedAt.toLocaleString()}
-                </div>
-                <div className="p-4 table-cell align-middle">
-                  <DeploymentProgressBar
-                    total={deployment.totalDevices}
-                    success={deployment.successCount}
-                    failed={deployment.failedCount}
-                    inProgress={deployment.inProgressCount}
-                  />
-                </div>
-                <div className="p-4 text-center table-cell align-middle">
-                  <StatusBadge status={deployment.status} />
-                </div>
-              </Link>
-            ))
-          )}
-        </div>
+  if (deployments.length === 0) {
+    return (
+      <div className="py-8 text-center text-neutral-500">
+        배포 이력이 없습니다.
       </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      {deployments.map((deployment) => (
+        <DeploymentCard key={deployment.id} deployment={deployment} />
+      ))}
     </div>
   );
 };

--- a/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import { FirmwareDeployment } from "../model/types";
 import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 import { DeploymentProgressBar } from "./DeploymentProgressBar";
+import { JSX } from "react";
 
 /**
  * 개별 배포 카드 컴포넌트
@@ -76,12 +77,17 @@ export interface FirmwareDeploymentListProps {
 
 /**
  * 펌웨어 배포 목록 컴포넌트
+ * 배포 ID, 타입, 대상, 시작 시간, 진행률, 상태 등의 정보를 카드 형식으로 표시합니다.
+ * @param deployments - 펌웨어 배포 목록
+ * @param isLoading - 데이터 로딩 상태
+ * @param error - 에러 메시지
+ * @returns {JSX.Element} 펌웨어 배포 목록 컴포넌트
  */
 export const FirmwareDeploymentList = ({
   deployments,
   isLoading,
   error,
-}: FirmwareDeploymentListProps) => {
+}: FirmwareDeploymentListProps): JSX.Element => {
   if (isLoading) {
     return <div className="flex justify-center py-8">로딩 중...</div>;
   }

--- a/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
@@ -57,7 +57,7 @@ const DeploymentCard = ({ deployment }: { deployment: FirmwareDeployment }) => {
       <div>
         <DeploymentProgressBar
           total={deployment.totalDevices}
-          succeded={deployment.successCount}
+          succeeded={deployment.successCount}
           failed={deployment.failedCount}
           inProgress={deployment.inProgressCount}
         />

--- a/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
+++ b/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
@@ -1,0 +1,211 @@
+import { useParams } from "react-router";
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
+import { MainTile } from "../widgets/layout/ui/MainTile";
+import { useFirmwareDeploymentDetail } from "../entities/firmware_deployment/api/useFirmwareDeploymentDetail";
+import { LabeledValue } from "../shared/ui/LabeledValue";
+import {
+  FirmwareDeploymentDetails,
+  FirmwareDeploymentDeviceStatus,
+} from "../entities/firmware_deployment/model/types";
+import { DeploymentStatusBadge } from "../entities/firmware_deployment/ui/DeploymentStatusBadge";
+import { DeploymentProgressBar } from "../entities/firmware_deployment/ui/DeploymentProgressBar";
+import { DeploymentDeviceStatusBadge } from "../entities/firmware_deployment/ui/DeploymentDeviceStatusBadge";
+
+/**
+ * 디바이스 상태에 따른 색상을 반환합니다.
+ */
+const getDeviceStatusColor = (status: string) => {
+  switch (status) {
+    case "SUCCESS":
+      return "text-green-600 bg-green-50";
+    case "IN_PROGRESS":
+      return "text-blue-600 bg-blue-50";
+    case "FAILED":
+      return "text-red-600 bg-red-50";
+    default:
+      return "text-gray-600 bg-gray-50";
+  }
+};
+
+/**
+ * 펌웨어 배포 세부 정보 컴포넌트
+ */
+const DeploymentInfo = ({
+  deployment,
+}: {
+  deployment: FirmwareDeploymentDetails;
+}) => {
+  return (
+    <div className="flex justify-between">
+      <div className="flex flex-col gap-6">
+        <LabeledValue
+          label="배포 ID"
+          value={deployment.id.toString()}
+          size="sm"
+        />
+        <LabeledValue
+          label="펌웨어 버전"
+          value={deployment.firmware.version}
+          size="sm"
+        />
+        <LabeledValue
+          label="시작 일시"
+          value={deployment.startedAt.toLocaleString()}
+          size="sm"
+        />
+        <LabeledValue
+          label="만료 일시"
+          value={deployment.expiredAt?.toLocaleString() ?? "없음"}
+          size="sm"
+        />
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-neutral-700">상태</span>
+          <DeploymentStatusBadge status={deployment.status} />
+        </div>
+      </div>
+
+      <div className="flex flex-col w-2/5 gap-4">
+        <div className="p-4 bg-gray-50 rounded-lg">
+          <div className="mb-3 text-sm font-medium text-neutral-700">
+            전체 진행률
+          </div>
+          <DeploymentProgressBar
+            total={deployment.totalDevices}
+            succeded={deployment.successCount}
+            failed={deployment.failedCount}
+            inProgress={deployment.inProgressCount}
+          />
+          <div className="text-xs text-neutral-500">
+            {deployment.successCount} / {deployment.totalDevices} 디바이스 완료
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div className="p-3 text-center bg-green-50 rounded-lg">
+            <div className="text-lg font-bold text-green-600">
+              {deployment.successCount}
+            </div>
+            <div className="text-xs text-green-600">성공</div>
+          </div>
+          <div className="p-3 text-center bg-blue-50 rounded-lg">
+            <div className="text-lg font-bold text-blue-600">
+              {deployment.inProgressCount}
+            </div>
+            <div className="text-xs text-blue-600">진행중</div>
+          </div>
+          <div className="p-3 text-center bg-red-50 rounded-lg">
+            <div className="text-lg font-bold text-red-600">
+              {deployment.failedCount}
+            </div>
+            <div className="text-xs text-red-600">실패</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * 디바이스 상태 목록 컴포넌트
+ */
+const DeviceStatusList = ({
+  devices,
+}: {
+  devices: FirmwareDeploymentDeviceStatus[];
+}) => {
+  return (
+    <div className="space-y-4">
+      {devices.length === 0 ? (
+        <div className="py-8 text-center text-gray-500">
+          배포 대상 디바이스가 없습니다.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {devices.map((device) => (
+            <div
+              key={device.id}
+              className="p-4 border border-gray-200 rounded-lg"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <span className="font-medium text-neutral-800">
+                    디바이스 ID: {device.id}
+                  </span>
+                  <DeploymentDeviceStatusBadge status={device.status} />
+                </div>
+                <span className="text-sm text-neutral-500">
+                  {device.lastUpdatedAt.toLocaleString()}
+                </span>
+              </div>
+
+              {device.status === "IN_PROGRESS" && (
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 bg-gray-200 rounded-full h-2">
+                    <div
+                      className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                      style={{ width: `${device.progress}%` }}
+                    ></div>
+                  </div>
+                  <span className="text-sm font-medium text-neutral-600">
+                    {device.progress}%
+                  </span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const FirmwareDeploymentDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const parsedId = id ? parseInt(id) : null;
+
+  if (parsedId === null || isNaN(parsedId)) {
+    return <div>배포 ID가 제공되지 않았습니다.</div>;
+  }
+
+  const { deployment, isLoading, error } =
+    useFirmwareDeploymentDetail(parsedId);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-8">로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div className="flex justify-center py-8 text-red-500">{error}</div>;
+  }
+
+  if (!deployment) {
+    return (
+      <div className="flex justify-center py-8">
+        배포 정보를 찾을 수 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-8">
+        <TitleTile
+          title="펌웨어 관리"
+          description="펌웨어 업로드 및 원격 업데이트"
+        />
+      </div>
+
+      <div className="mb-6">
+        <MainTile title="펌웨어 배포 세부 정보">
+          <DeploymentInfo deployment={deployment} />
+        </MainTile>
+      </div>
+
+      <div>
+        <MainTile title="디바이스별 진행 상황">
+          <DeviceStatusList devices={deployment.devices} />
+        </MainTile>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
+++ b/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
@@ -12,22 +12,6 @@ import { DeploymentProgressBar } from "../entities/firmware_deployment/ui/Deploy
 import { DeploymentDeviceStatusBadge } from "../entities/firmware_deployment/ui/DeploymentDeviceStatusBadge";
 
 /**
- * 디바이스 상태에 따른 색상을 반환합니다.
- */
-const getDeviceStatusColor = (status: string) => {
-  switch (status) {
-    case "SUCCESS":
-      return "text-green-600 bg-green-50";
-    case "IN_PROGRESS":
-      return "text-blue-600 bg-blue-50";
-    case "FAILED":
-      return "text-red-600 bg-red-50";
-    default:
-      return "text-gray-600 bg-gray-50";
-  }
-};
-
-/**
  * 펌웨어 배포 세부 정보 컴포넌트
  */
 const DeploymentInfo = ({
@@ -159,6 +143,10 @@ const DeviceStatusList = ({
   );
 };
 
+/**
+ * 펌웨어 배포 세부 정보 페이지 컴포넌트
+ * 배포 ID를 URL 파라미터로 받아 해당 배포의 세부 정보를 표시합니다.
+ */
 export const FirmwareDeploymentDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const parsedId = id ? parseInt(id) : null;

--- a/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
+++ b/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
@@ -55,7 +55,7 @@ const DeploymentInfo = ({
           </div>
           <DeploymentProgressBar
             total={deployment.totalDevices}
-            succeded={deployment.successCount}
+            succeeded={deployment.successCount}
             failed={deployment.failedCount}
             inProgress={deployment.inProgressCount}
           />


### PR DESCRIPTION
# Changelog
- 펌웨어 배포 데이터를 나타내기 위한 컴포넌트들을 작성하였습니다.
  - `DeploymentProgressBar`: 배포 진행 상태를 바 형태로 시각화하는 컴포넌트
  - `DeploymentStatusBadge`: 배포 진행 상태를 뱃지 형태로 나타내는 컴포넌트
  - `DeploymentDeviceStatusBadge`: 배포 내 각 기기별 상태를 뱃지 형태로 나타내는 컴포넌트
- 펌웨어 배포들을 **카드 리스트**로 나타내는 `FirmwareDeploymentList`를 구현하였습니다.
- 펌웨어 세부 정보 API 를 요청하여 데이터를 가져오는 커스텀 훅 `useFirmwareDeploymentDetail`을 작성하였습니다.

# Testing
- Mock 데이터로 테스트

https://github.com/user-attachments/assets/a374a422-6e5b-4a58-873e-884f7741113f

# Ops Impact
N/A

# Version Compatibility
N/A