### PR TITLE
[Frontend] 백엔드 API 응답 변경에 따른 DTO, 모델 변경

### DIFF
--- a/frontend/src/entities/firmware_deployment/api/api.ts
+++ b/frontend/src/entities/firmware_deployment/api/api.ts
@@ -33,7 +33,7 @@ export const firmwareDeploymentApiService = {
   ): Promise<PaginatedFirmwareDeployments> => {
     const { data } = await apiClient.get<
       PaginatedApiResponse<FirmwareDeploymentResponse>
-    >(`/api/firmware-deployments`, {
+    >(`/api/firmwares/deployment/list`, {
       params: { page, limit, search: query },
     });
 
@@ -56,7 +56,7 @@ export const firmwareDeploymentApiService = {
     id: number,
   ): Promise<FirmwareDeploymentDetails> => {
     const { data } = await apiClient.get<FirmwareDeploymentDetailsResponse>(
-      `/api/firmware-deployments/${id}`,
+      `/api/firmwares/deployment/${id}`,
     );
 
     return toFirmwareDeploymentDetails(data);

--- a/frontend/src/entities/firmware_deployment/model/mappers.ts
+++ b/frontend/src/entities/firmware_deployment/model/mappers.ts
@@ -14,7 +14,7 @@ export const toFirmwareDeploymentDeviceStatus = (
   dto: FirmwareDeploymentDeviceStatusResponse,
 ): FirmwareDeploymentDeviceStatus => ({
   ...dto,
-  lastUpdatedAt: new Date(dto.lastUpdatedAt),
+  timestamp: new Date(dto.timestamp),
 });
 
 /**
@@ -24,8 +24,8 @@ export const toFirmwareDeployment = (
   dto: FirmwareDeploymentResponse,
 ): FirmwareDeployment => ({
   ...dto,
-  startedAt: new Date(dto.startedAt),
-  expiredAt: dto.expiredAt ? new Date(dto.expiredAt) : null,
+  deployedAt: new Date(dto.deployedAt),
+  expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : null,
 });
 
 /**

--- a/frontend/src/entities/firmware_deployment/model/types.ts
+++ b/frontend/src/entities/firmware_deployment/model/types.ts
@@ -4,8 +4,7 @@ import { Firmware } from "../../firmware/model/types";
 /**
  * 펌웨어 배포 대상 인터페이스
  */
-export interface FirmwareDeploymentTarget {
-  type: "REGION" | "GROUP" | "DEVICE";
+export interface DeploymentTargetInfo {
   id: number;
   name: string;
 }
@@ -17,9 +16,9 @@ export interface FirmwareDeploymentTarget {
  */
 export interface FirmwareDeploymentDeviceStatusResponse {
   id: number;
-  status: "SUCCESS" | "IN_PROGRESS" | "FAILED";
+  status: "WAITING" | "SUCCESS" | "IN_PROGRESS" | "FAILED";
   progress: number;
-  lastUpdatedAt: string;
+  timestamp: string;
 }
 
 /**
@@ -28,14 +27,15 @@ export interface FirmwareDeploymentDeviceStatusResponse {
 export interface FirmwareDeploymentResponse {
   id: number;
   firmware: Firmware;
-  target: FirmwareDeploymentTarget;
-  totalDevices: number;
+  deploymentType: "REGION" | "GROUP" | "DEVICE";
+  targetInfo: DeploymentTargetInfo[];
+  totalCount: number;
   successCount: number;
   inProgressCount: number;
   failedCount: number;
   status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
-  startedAt: string;
-  expiredAt: string | null;
+  deployedAt: string;
+  expiresAt: string | null;
 }
 
 /**
@@ -54,9 +54,9 @@ export interface FirmwareDeploymentDetailsResponse
  */
 export type FirmwareDeploymentDeviceStatus = {
   id: number;
-  status: "SUCCESS" | "IN_PROGRESS" | "FAILED" | "TIMEOUT";
+  status: "WAITING" | "SUCCESS" | "IN_PROGRESS" | "FAILED" | "TIMEOUT";
   progress: number;
-  lastUpdatedAt: Date;
+  timestamp: Date;
 };
 
 /**
@@ -66,14 +66,15 @@ export type FirmwareDeploymentDeviceStatus = {
 export type FirmwareDeployment = {
   id: number;
   firmware: Firmware;
-  target: FirmwareDeploymentTarget;
-  totalDevices: number;
+  deploymentType: "REGION" | "GROUP" | "DEVICE";
+  targetInfo: DeploymentTargetInfo[];
+  totalCount: number;
   successCount: number;
   inProgressCount: number;
   failedCount: number;
   status: "PENDING" | "IN_PROGRESS" | "COMPLETED";
-  startedAt: Date;
-  expiredAt: Date | null;
+  deployedAt: Date;
+  expiresAt: Date | null;
 };
 
 /**

--- a/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/DeploymentDeviceStatusBadge.tsx
@@ -22,6 +22,11 @@ export const DeploymentDeviceStatusBadge = ({
   let label = "";
 
   switch (status) {
+    case "WAITING":
+      bgColor = "bg-yellow-100";
+      textColor = "text-yellow-800";
+      label = "대기 중";
+      break;
     case "SUCCESS":
       bgColor = "bg-green-100";
       textColor = "text-green-800";

--- a/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
+++ b/frontend/src/entities/firmware_deployment/ui/FirmwareDeploymentList.tsx
@@ -22,7 +22,7 @@ const DeploymentCard = ({ deployment }: { deployment: FirmwareDeployment }) => {
           <DeploymentStatusBadge status={deployment.status} />
         </div>
         <span className="text-sm text-neutral-500">
-          {deployment.startedAt.toLocaleString()}
+          {deployment.deployedAt.toLocaleString()}
         </span>
       </div>
 
@@ -32,13 +32,13 @@ const DeploymentCard = ({ deployment }: { deployment: FirmwareDeployment }) => {
           <div>
             <span className="text-xs text-neutral-500">타입: </span>
             <span className="text-sm text-neutral-800">
-              {deployment.target.type}
+              {deployment.deploymentType}
             </span>
           </div>
           <div>
             <span className="text-xs text-neutral-500">대상: </span>
             <span className="text-sm text-neutral-800">
-              {deployment.target.name}
+              {deployment.targetInfo.map((info) => info.name).join(", ")}
             </span>
           </div>
         </div>
@@ -56,7 +56,7 @@ const DeploymentCard = ({ deployment }: { deployment: FirmwareDeployment }) => {
       {/* 진행률 */}
       <div>
         <DeploymentProgressBar
-          total={deployment.totalDevices}
+          total={deployment.totalCount}
           succeeded={deployment.successCount}
           failed={deployment.failedCount}
           inProgress={deployment.inProgressCount}

--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -5,6 +5,7 @@ import { Device } from "../../../entities/device/model/types";
 import { GroupApiService } from "../../../entities/group/api/api";
 import { deviceApiService } from "../../../entities/device/api/api";
 import { apiClient } from "../../../shared/api/client";
+import { DeploymentType } from "../model/types";
 
 /**
  * Fetches all available regions from the API
@@ -33,6 +34,7 @@ export const fetchDevices = async (): Promise<Device[]> => {
 /**
  * Requests a firmware deployment to specified regions, groups, and devices
  * @param {number} firmwareId - The ID of the firmware to deploy
+ * @param {string} deploymentType - The type of deployment (e.g., "DEVICE", "GROUP", "REGION")
  * @param {Region[]} regions - Array of regions to deploy the firmware to
  * @param {Group[]} groups - Array of groups to deploy the firmware to
  * @param {Device[]} devices - Array of devices to deploy the firmware to
@@ -40,11 +42,13 @@ export const fetchDevices = async (): Promise<Device[]> => {
  */
 export const requestFirmwareDeploy = async (
   firmwareId: number,
+  deploymentType: DeploymentType,
   regions: Region[],
   groups: Group[],
   devices: Device[],
 ): Promise<void> => {
   await apiClient.post(`/api/firmwares/metadata/${firmwareId}/deployment`, {
+    deploymentType,
     regionIds: regions.map((region) => region.regionId),
     groupIds: groups.map((group) => group.groupId),
     deviceIds: devices.map((device) => device.deviceId),

--- a/frontend/src/features/firmware_deploy/model/types.ts
+++ b/frontend/src/features/firmware_deploy/model/types.ts
@@ -8,3 +8,12 @@ export interface DeploymentRequest {
   targetType: DeployCategory;
   targetIds: string[];
 }
+
+/**
+ * Enum for deployment types
+ */
+export enum DeploymentType {
+  DEVICE = "DEVICE",
+  GROUP = "GROUP",
+  REGION = "REGION",
+}

--- a/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
+++ b/frontend/src/features/firmware_deploy/ui/FirmwareDeploy.tsx
@@ -1,5 +1,5 @@
 import { JSX, useEffect, useState } from "react";
-import { DeployCategory } from "../model/types";
+import { DeployCategory, DeploymentType } from "../model/types";
 import { Region } from "../../../entities/region/model/types";
 import { Device } from "../../../entities/device/model/types";
 import {
@@ -209,8 +209,16 @@ export const FirmwareDeploy = ({
     setError(null);
 
     try {
+      const deploymentType =
+        deployCategory === "region"
+          ? DeploymentType.REGION
+          : deployCategory === "group"
+            ? DeploymentType.GROUP
+            : DeploymentType.DEVICE;
+
       await requestFirmwareDeploy(
         firmware.id,
+        deploymentType,
         selectedRegions,
         selectedGroups,
         selectedDevices,

--- a/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
+++ b/frontend/src/pages/FirmwareDeploymentDetailPage.tsx
@@ -34,12 +34,12 @@ const DeploymentInfo = ({
         />
         <LabeledValue
           label="시작 일시"
-          value={deployment.startedAt.toLocaleString()}
+          value={deployment.deployedAt.toLocaleString()}
           size="sm"
         />
         <LabeledValue
           label="만료 일시"
-          value={deployment.expiredAt?.toLocaleString() ?? "없음"}
+          value={deployment.expiresAt?.toLocaleString() ?? "없음"}
           size="sm"
         />
         <div className="flex items-center gap-2">
@@ -54,13 +54,13 @@ const DeploymentInfo = ({
             전체 진행률
           </div>
           <DeploymentProgressBar
-            total={deployment.totalDevices}
+            total={deployment.totalCount}
             succeeded={deployment.successCount}
             failed={deployment.failedCount}
             inProgress={deployment.inProgressCount}
           />
           <div className="text-xs text-neutral-500">
-            {deployment.successCount} / {deployment.totalDevices} 디바이스 완료
+            {deployment.successCount} / {deployment.totalCount} 디바이스 완료
           </div>
         </div>
 
@@ -118,7 +118,7 @@ const DeviceStatusList = ({
                   <DeploymentDeviceStatusBadge status={device.status} />
                 </div>
                 <span className="text-sm text-neutral-500">
-                  {device.lastUpdatedAt.toLocaleString()}
+                  {device.timestamp.toLocaleString()}
                 </span>
               </div>
 


### PR DESCRIPTION
# Changelog
백엔드 API 응답 구조가 변경됨에 따라 프론트엔드의 DTO, 모델을 그에 맞게 변경하였습니다.

- API URL
  - `/api/firmware-deployments` -> `/api/firmwares/deployment/list` 변경
  - `/api/firmware-deployments/${id}` -> `/api/firmwares/deployment/{id}` 변경
- 디바이스 다운로드 상태 (FirmwareDeploymentDeviceStatus)
  - `WAITING` 추가
- 배포 리스트
  - `deploymentType` 추가
  - `target` -> `targetInfo` 변경
  - `totalDevices` -> `totalCount` 변경
  - `startedAt` -> `deployedAt` 변경
  - `expiredAt` -> `expiresAt` 변경
- 기타 등등

# Testing
- 렌더링 확인
<img width="1702" height="1011" alt="image" src="https://github.com/user-attachments/assets/e6af9570-f041-4479-ae73-f34e72b06b2a" />

<img width="1684" height="1004" alt="image" src="https://github.com/user-attachments/assets/c4c054c5-69db-4866-ae68-b6f7885aee9a" />

# Ops Impact
N/A

# Version Compatibility
N/A