### PR TITLE
[Frontend] S3 호스팅 웹페이지 새로고침 시 NotFound 에러 해결

### DIFF
--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -34,7 +34,7 @@ export const fetchDevices = async (): Promise<Device[]> => {
 /**
  * Requests a firmware deployment to specified regions, groups, and devices
  * @param {number} firmwareId - The ID of the firmware to deploy
- * @param {string} deploymentType - The type of deployment (e.g., "DEVICE", "GROUP", "REGION")
+ * @param {DeploymentType} deploymentType - The type of deployment (e.g., "DEVICE", "GROUP", "REGION")
  * @param {Region[]} regions - Array of regions to deploy the firmware to
  * @param {Group[]} groups - Array of groups to deploy the firmware to
  * @param {Device[]} devices - Array of devices to deploy the firmware to

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -108,6 +108,10 @@ resource "aws_s3_bucket_website_configuration" "frontend_bucket" {
   index_document {
     suffix = "index.html"
   }
+
+  error_document {
+    key = "index.html"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "frontend_bucket" {


### PR DESCRIPTION
# Changelog
기존에 S3 페이지를 새로고침하면 404 Not Found - No Such Key 에러가 뜨는 현상이 발생하였습니다.
이는 React가 SPA이고 `index.html`을 받아서 `react-router-dom`으로 주소창 URL만 바꾸고 다른 컴포넌트를 로딩하는 형식이기 때문에, 새로고침 시 `index.html`이 아닌 실제 해당 URL에 있는 리소스를 다운로드받으려고 해서 발생하는 현상입니다.

- S3 파일이 존재하지 않아서 404 오류가 발생하는 경우, `index.html`을 반환하도록 설정하였습니다. (이렇게 하면 사용자는 index.html을 받아서 정상적으로 react-router-dom이 실행되고 해당 URL의 컴포넌트를 렌더링합니다.
- DocString에 Typo를 발견하여 수정하였습니다.

# Testing
https://github.com/user-attachments/assets/521d490c-8732-4952-8913-9947af3d5e07

# Ops Impact
N/A

# Version Compatibility
N/A