### PR TITLE
[Mqtt handler] 자동 재연결 및 재구독 로직 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/QuestDbRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/QuestDbRepository.java
@@ -56,6 +56,7 @@ public class QuestDbRepository {
             e.setChecksumVerified(rs.getBoolean("checksum_verified"));
             e.setDownloadTime(rs.getDouble("download_time"));
             e.setTimestamp(rs.getTimestamp("timestamp"));
+
             return e;
         }
     };

--- a/mqtt-handler/init/cmd/cmd.go
+++ b/mqtt-handler/init/cmd/cmd.go
@@ -38,9 +38,6 @@ func NewCmd() *Cmd {
 	// MQTT 연결
 	c.mqttClient.Connect(c.config.MqttBroker.Url, c.config.MqttBroker.ClientId)
 
-	// MQTT Subscribe
-	c.mqttClient.SubscribeAllTopics()
-
 	// HTTP 서버 시작
 	if err := c.network.ServerStart(c.config.Server.Port); err != nil {
 		panic(err)


### PR DESCRIPTION
# Changelog

- MQTT 클라이언트에 연결 안정성 옵션 추가
 - OnConnect 콜백에서 SubscribeAllTopics() 실행하여 재연결 시 자동 구독 복구

# Testing

- 로컬 환경에서 EMQX 브로커와 연결 후 네트워크를 강제로 끊고 다시 연결
- 재연결 성공 확인 후 `SubscribeAllTopics()`가 실행되어 정상적으로 토픽 구독이 복구됨 확인

<img width="879" height="149" alt="image" src="https://github.com/user-attachments/assets/c652e9aa-e0be-4f4c-977b-754379bf853b" />

# Ops Impact

N/A

# Version Compatibility

N/A