### PR TITLE
[Backend] 배포 트리거 기반 동적 스케줄러 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
@@ -7,28 +7,30 @@ import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareDeploymentDevice
 import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareDeploymentRepository;
 import com.coffee_is_essential.iot_cloud_ota.repository.OverallDeploymentStatusRepository;
 import com.coffee_is_essential.iot_cloud_ota.repository.QuestDbRepository;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 /**
- * 배포 상태를 주기적으로 점검하는 스케줄러 서비스.
- * Redis에 저장된 배포 키(commandId)를 순회하면서 각 디바이스의 다운로드 이벤트를 조회하고,
- * 배포 완료 / 실패 / 타임아웃 여부를 판별하여 DB에 반영한다.
+ * 배포 상태를 주기적으로 점검하는 스케줄러 서비스
+ * Redis에 저장된 배포 키(commandId)를 기반으로 각 디바이스의 다운로드 이벤트를 조회하고,
+ * 배포 완료 / 실패 / 타임아웃 여부를 판별하여 DB에 반영함
+ * 배포별로 독립된 스케줄러를 관리하며, 조건이 충족되면 자동으로 스케줄러를 종료함
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DeployJudgeScheduler {
     private final StringRedisTemplate srt;
@@ -39,49 +41,91 @@ public class DeployJudgeScheduler {
     private final EntityManager em;
     private final QuestDbRepository questDbRepository;
 
-    private static final int SCAN_COUNT = 200;
+    private final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 
-    /**
-     * 30초마다 실행되며, Redis에 저장된 배포 commandId들을 스캔한다.
-     */
-    @Scheduled(fixedDelay = 600000)
-    public void dumpDeploySets() {
-        System.out.println("=== Redis Dump Start ===");
-
-        var cf = Objects.requireNonNull(srt.getConnectionFactory());
-        try (RedisConnection conn = cf.getConnection();
-             Cursor<byte[]> cursor = conn.scan(ScanOptions.scanOptions().match("*").count(SCAN_COUNT).build())) {
-            while (cursor.hasNext()) {
-                String commandId = new String(cursor.next(), StandardCharsets.UTF_8);
-
-                try {
-                    List<Long> deviceIds = deploymentRedisService.getAllDeviceIdsFromRedisById(commandId);
-                    judge(commandId, deviceIds);
-                } catch (Exception e) {
-                    System.out.printf("[KEY ERROR] commandId=%s, err=%s%n", commandId, e.getMessage());
-                }
-            }
-        } catch (Exception e) {
-            System.out.println("[SCAN ERROR] " + e.getMessage());
-        }
-
-        System.out.println("=== Redis Dump End ===");
+    @PostConstruct
+    public void init() {
+        taskScheduler.setPoolSize(10);
+        taskScheduler.initialize();
     }
 
     /**
-     * 주어진 commandId와 디바이스 리스트에 대해 배포 상태를 판별한다.
-     * 1. QuestDB에서 최신 다운로드 이벤트를 가져와 완료된 디바이스 처리
-     * 2. Redis에 남은 디바이스가 없으면 전체 배포 완료 처리
-     * 3. 만료 시간이 지나면 타임아웃 처리
+     * 특정 배포(commandId)에 대한 스케줄러를 시작한다.
+     * 30초마다 dumpDeploySet을 실행하며,
+     * 이미 해당 commandId의 스케줄러가 실행 중이면 새로 시작하지 않음
      *
      * @param commandId 배포 식별자
-     * @param deviceIds 해당 배포에 포함된 디바이스 ID 리스트
+     */
+    public synchronized void startScheduler(String commandId) {
+        if (scheduledTasks.containsKey(commandId)) {
+            log.warn("[WARN] Scheduler already running for commandId={}", commandId);
+            return;
+        }
+        ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(
+                () -> dumpDeploySet(commandId),
+                Duration.ofSeconds(60)
+        );
+        scheduledTasks.put(commandId, future);
+        log.info("[START] Scheduler started for commandId={}", commandId);
+    }
+
+    /**
+     * 특정 배포(commandId)에 대한 스케줄러를 중지한다.
+     * 맵에서 해당 commandId의 ScheduledFuture를 제거하고 cancel 처리한다.
+     *
+     * @param commandId 배포 식별자
+     */
+    public synchronized void stopScheduler(String commandId) {
+        ScheduledFuture<?> future = scheduledTasks.remove(commandId);
+        if (future != null) {
+            future.cancel(false);
+            log.info("[STOP] Scheduler stopped for commandId={}", commandId);
+        }
+    }
+
+    /**
+     * Redis에서 특정 배포(commandId)의 디바이스 목록을 스캔하여 상태를 점검한다.
+     * Redis에 디바이스 ID가 없으면 스케줄러를 종료하고,
+     * 존재하면 judge 메서드를 호출한다.
+     *
+     * @param commandId 배포 식별자
+     */
+    private void dumpDeploySet(String commandId) {
+        try {
+            List<Long> deviceIds = deploymentRedisService.getAllDeviceIdsFromRedisById(commandId);
+            if (deviceIds.isEmpty()) {
+                log.info("[ERROR] No devices left in Redis for commandId={}, stopping scheduler", commandId);
+                stopScheduler(commandId);
+                return;
+            }
+            judge(commandId, deviceIds);
+        } catch (Exception e) {
+            log.error("[ERROR] Error while scanning Redis for commandId={}, err={}", commandId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 특정 배포(commandId)의 디바이스 상태를 판별한다.
+     * QuestDB에서 최신 다운로드 이벤트를 조회하여 완료된 이벤트를 DB에 반영하고,
+     * Redis에서 제거한다. 모든 디바이스가 완료되었거나 만료 시간이 지난 경우
+     * 전체 배포 상태를 COMPLETED로 저장하고 스케줄러를 종료한다.
+     *
+     * @param commandId 배포 식별자
+     * @param deviceIds 배포에 포함된 디바이스 ID 리스트
      */
     @Transactional
     public void judge(String commandId, List<Long> deviceIds) {
         FirmwareDeployment firmwareDeployment = firmwareDeploymentRepository.findByCommandIdOrElseThrow(commandId);
         OffsetDateTime expiresAt = firmwareDeployment.getExpiresAt();
-        System.out.printf("[SET] commandId=%s, devices=%s, expires=%s%n", commandId, deviceIds, expiresAt);
+
+        log.info(
+                "[CHECKING] Judge started for commandId={}, deviceCount={}, expiresAt={}, deviceIds={}",
+                commandId,
+                deviceIds.size(),
+                expiresAt.toInstant(),
+                deviceIds
+        );
 
         List<FirmwareDownloadEvents> downloadEvents = questDbRepository.findLatestPerDeviceByCommandIdAndDeviceIds(commandId, deviceIds);
         List<FirmwareDownloadEvents> completedEvents = downloadEvents.stream()
@@ -94,18 +138,28 @@ public class DeployJudgeScheduler {
 
         Long size = srt.opsForSet().size(commandId);
         if (size == null || size == 0) {
-            overallDeploymentStatusRepository.save(new OverallDeploymentStatus(firmwareDeployment, OverallStatus.COMPLETED));
+            log.info("[SUCCESS] Deployment completed successfully, commandId={}", commandId);
+            overallDeploymentStatusRepository.save(
+                    new OverallDeploymentStatus(firmwareDeployment, OverallStatus.COMPLETED)
+            );
+            stopScheduler(commandId);
             return;
         }
 
         if (Instant.now().isAfter(expiresAt.toInstant())) {
+            log.warn("[TIMEOUT] Deployment expired (timeout), commandId={}", commandId);
             processTimeoutEvents(commandId, firmwareDeployment);
-            overallDeploymentStatusRepository.save(new OverallDeploymentStatus(firmwareDeployment, OverallStatus.COMPLETED));
+            overallDeploymentStatusRepository.save(
+                    new OverallDeploymentStatus(firmwareDeployment, OverallStatus.COMPLETED)
+            );
+            stopScheduler(commandId);
         }
     }
 
     /**
-     * 만료된 배포에 대해 타임아웃 상태로 저장하고 Redis 키를 제거한다.
+     * 만료된 배포(commandId)에 대해 TIMEOUT 처리한다.
+     * 남은 모든 디바이스를 TIMEOUT 상태로 저장하고,
+     * Redis에도 반영한 뒤 Redis key를 삭제한다.
      *
      * @param commandId  배포 식별자
      * @param deployment 배포 엔티티

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareDeploymentService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/FirmwareDeploymentService.java
@@ -45,6 +45,7 @@ public class FirmwareDeploymentService {
     private final QuestDbRepository questDbRepository;
     private final CloudFrontSignedUrlService cloudFrontSignedUrlService;
     private final DeploymentRedisService deploymentRedisService;
+    private final DeployJudgeScheduler deployJudgeScheduler;
     private static final int TIMEOUT = 10;
 
     /**
@@ -95,6 +96,7 @@ public class FirmwareDeploymentService {
         FirmwareDeploymentDto deploymentDto = new FirmwareDeploymentDto(signedUrl, deployInfo, deviceInfos, TIMEOUT);
         sendMqttHandler(deploymentDto);
         deploymentRedisService.addDevices(firmwareDeployment.getCommandId(), deviceInfos);
+        deployJudgeScheduler.startScheduler(firmwareDeployment.getCommandId());
         return deploymentDto;
     }
 


### PR DESCRIPTION
# Changelog

- 기존 `@Scheduled` 기반의 전역 스케줄러를 제거하고, 배포 시점에 동적으로 트리거되는 스케줄러로 변경
- 배포별 `commandId` 단위로 독립적인 스케줄러 실행 및 관리
- 스케줄러는 60초마다 Redis 상태를 확인하여 디바이스 이벤트 처리
  - 모든 디바이스 완료 시 → 배포 상태를 COMPLETED 처리 후 스케줄러 자동 종료
  - Timeout 시 → TIMEOUT 처리 후 스케줄러 자동 종료
- Slf4j 기반 로그 추가

# Testing

- 배포 요청 시 `startScheduler(commandId)` 가 정상적으로 호출되는지 확인
<img width="737" height="151" alt="image" src="https://github.com/user-attachments/assets/c5f97cc3-f3c2-4b44-8ec3-cf5a509b1dbe" />

# Ops Impact

N/A

# Version Compatibility

N/A