### PR TITLE
[Frontend] 배포 요청 토스트 메시지로 변경

### DIFF
--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -47,10 +47,13 @@ export const requestFirmwareDeploy = async (
   groups: Group[],
   devices: Device[],
 ): Promise<void> => {
-  await apiClient.post(`/api/firmwares/metadata/${firmwareId}/deployment`, {
-    deploymentType,
-    regionIds: regions.map((region) => region.regionId),
-    groupIds: groups.map((group) => group.groupId),
-    deviceIds: devices.map((device) => device.deviceId),
-  });
+  const result = await apiClient.post(
+    `/api/firmwares/metadata/${firmwareId}/deployment`,
+    {
+      deploymentType,
+      regionIds: regions.map((region) => region.regionId),
+      groupIds: groups.map((group) => group.groupId),
+      deviceIds: devices.map((device) => device.deviceId),
+    },
+  );
 };

--- a/frontend/src/features/firmware_deploy/api/api.ts
+++ b/frontend/src/features/firmware_deploy/api/api.ts
@@ -47,13 +47,10 @@ export const requestFirmwareDeploy = async (
   groups: Group[],
   devices: Device[],
 ): Promise<void> => {
-  const result = await apiClient.post(
-    `/api/firmwares/metadata/${firmwareId}/deployment`,
-    {
-      deploymentType,
-      regionIds: regions.map((region) => region.regionId),
-      groupIds: groups.map((group) => group.groupId),
-      deviceIds: devices.map((device) => device.deviceId),
-    },
-  );
+  await apiClient.post(`/api/firmwares/metadata/${firmwareId}/deployment`, {
+    deploymentType,
+    regionIds: regions.map((region) => region.regionId),
+    groupIds: groups.map((group) => group.groupId),
+    deviceIds: devices.map((device) => device.deviceId),
+  });
 };

--- a/frontend/src/features/firmware_deploy/api/useFirmwareDeploy.tsx
+++ b/frontend/src/features/firmware_deploy/api/useFirmwareDeploy.tsx
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { requestFirmwareDeploy } from "./api";
+import { DeploymentType } from "../model/types";
+
+// 변수 객체의 타입을 정의합니다.
+interface DeployFirmwareVariables {
+  firmwareId: number;
+  deploymentType: DeploymentType;
+  regions: any[];
+  groups: any[];
+  devices: any[];
+}
+
+export const useFirmwareDeploy = () => {
+  const queryClient = useQueryClient();
+
+  const deployFirmware = async ({
+    firmwareId,
+    deploymentType,
+    regions,
+    groups,
+    devices,
+  }: DeployFirmwareVariables) => {
+    await requestFirmwareDeploy(
+      firmwareId,
+      deploymentType,
+      regions,
+      groups,
+      devices,
+    );
+    queryClient.invalidateQueries({ queryKey: ["firmwares"] });
+  };
+
+  return useMutation<void, Error, DeployFirmwareVariables>({
+    mutationFn: deployFirmware,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["firmware-deployments"] });
+    },
+    onError: (error) => {
+      console.error("펌웨어 배포에 실패했습니다:", error);
+    },
+  });
+};

--- a/frontend/src/features/firmware_deploy/api/useFirmwareDeploy.tsx
+++ b/frontend/src/features/firmware_deploy/api/useFirmwareDeploy.tsx
@@ -11,6 +11,11 @@ interface DeployFirmwareVariables {
   devices: any[];
 }
 
+/**
+ * 펌웨어 배포 프로세스를 담당하는 커스텀 훅
+ * @description useMutation을 사용하여 펌웨어 배포를 처리하고,
+ * 성공 시 펌웨어 배포 목록 쿼리를 무효화하여 자동 리프레시를 유발합니다.
+ */
 export const useFirmwareDeploy = () => {
   const queryClient = useQueryClient();
 
@@ -28,7 +33,6 @@ export const useFirmwareDeploy = () => {
       groups,
       devices,
     );
-    queryClient.invalidateQueries({ queryKey: ["firmwares"] });
   };
 
   return useMutation<void, Error, DeployFirmwareVariables>({


### PR DESCRIPTION
# Changelog
- 배포 요청을 토스트 메시지로 변경하였습니다.
  - PENDING, SUCCESS, ERROR 에 대해 토스트 메시지로 알려주도록 구성했습니다.
- 배포 요청 시 현재 배포 리스트 `firmware-deployments` 키에 대한 캐시 값을 무효화합니다. 이는 배포 리스트에 새로운 배포를 포함하기 위함입니다.

# Testing
https://github.com/user-attachments/assets/27e20f2d-4f99-4467-bf03-761b961bb1fb

# Ops Impact
N/A

# Version Compatibility
N/A