### PR TITLE
[Frontend] 릴리즈 노트 줄바꿈 안되는 오류 수정

### DIFF
--- a/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareDetail.tsx
@@ -106,7 +106,7 @@ export const FirmwareDetail = ({
         <div className="mb-2 text-sm font-normal text-neutral-600">
           릴리즈 노트
         </div>
-        <div className="flex-1 p-2 overflow-auto text-sm font-normal border border-gray-200 rounded-lg shadow-sm text-neutral-800">
+        <div className="flex-1 p-2 overflow-auto text-sm font-normal border border-gray-200 rounded-lg shadow-sm text-neutral-800 whitespace-pre-line">
           {firmware?.releaseNote}
         </div>
       </div>

--- a/frontend/src/entities/firmware/ui/FirmwareList.tsx
+++ b/frontend/src/entities/firmware/ui/FirmwareList.tsx
@@ -57,8 +57,10 @@ export const FirmwareList = ({
               <div className="col-span-2 text-sm text-neutral-600">
                 {firmware.createdAt.toLocaleString()}
               </div>
-              <div className="col-span-4 text-sm text-neutral-600">
-                {firmware.releaseNote}
+              <div className="col-span-4 text-sm text-neutral-600 whitespace-pre-line">
+                {firmware.releaseNote.length > 50
+                  ? firmware.releaseNote.slice(0, 50) + "..."
+                  : firmware.releaseNote}
               </div>
             </Link>
           ))}


### PR DESCRIPTION
# Changelog
- 릴리즈 노트에 `whitespace-pre-line` 옵션을 추가하여 줄바꿈되도록 설정하였습니다.
- 펌웨어 리스트 페이지에서는 최대 50자만 표기하고, 뒤는 `...` 으로 잘랐습니다.

# Testing
<img width="1698" height="1009" alt="image" src="https://github.com/user-attachments/assets/e99a5d57-7d2d-4a22-a3b1-fda5d04bd1c0" />

<img width="1702" height="1009" alt="image" src="https://github.com/user-attachments/assets/5cf62c62-7fbb-479d-a117-660093f415f5" />


# Ops Impact
N/A

# Version Compatibility
N/A