### PR TITLE
[Frontend] 광고 세부 정보 페이지 구현

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -8,6 +8,7 @@ import { FirmwareDetailPage } from "../pages/FirmwareDetailPage";
 import { DevicePage } from "../pages/DevicePage";
 import { FirmwareDeploymentPage } from "../pages/FirmwareDeploymentPage";
 import { FirmwareDeploymentDetailPage } from "../pages/FirmwareDeploymentDetailPage";
+import { AdDetailPage } from "../pages/AdDetailPage";
 
 export const Router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ export const Router = createBrowserRouter([
       },
       { path: "device", element: <DevicePage /> },
       { path: "ads", element: <AdListPage /> },
+      { path: "ads/:id", element: <AdDetailPage /> },
       { path: "monitoring", element: <MonitoringPage /> },
     ],
   },

--- a/frontend/src/entities/advertisement/api/api.ts
+++ b/frontend/src/entities/advertisement/api/api.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "../../../shared/api/client";
 import { PaginatedApiResponse } from "../../../shared/api/types";
-import { Ad, PaginatedAds } from "../model/types";
+import { Ad, AdDetails, PaginatedAds } from "../model/types";
 
 /**
  * 광고 관련 API 요청을 처리하는 서비스
@@ -40,6 +40,26 @@ export const adApiService = {
         modifiedAt: new Date(item.modifiedAt),
       })),
       paginationMeta: data.paginationMeta,
+    };
+  },
+
+  /**
+   * 특정 ID의 광고 정보를 조회합니다.
+   * @async
+   * @param {number} id - 조회할 광고의 고유 ID
+   * @returns {Promise<AdDetails>} - 해당 광고 정보와 관련된 기기 목록을 반환합니다.
+   * @example
+   * const adDetails = await adApiService.getAd(1);
+   */
+  getAdDetail: async (id: number): Promise<AdDetails> => {
+    const { data } = await apiClient.get<AdDetails>(`/api/ads/metadata/${id}`);
+    return {
+      adsMetadata: {
+        ...data.adsMetadata,
+        createdAt: new Date(data.adsMetadata.createdAt),
+        modifiedAt: new Date(data.adsMetadata.modifiedAt),
+      },
+      devices: data.devices,
     };
   },
 };

--- a/frontend/src/entities/advertisement/api/useAdDetail.tsx
+++ b/frontend/src/entities/advertisement/api/useAdDetail.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { AdDetails } from "../model/types";
+import { adApiService } from "./api";
+
+/**
+ * 광고 세부 정보를 가져오는 커스텀 훅의 결과 타입
+ */
+export interface AdDetailHookResult {
+  adDetail: AdDetails | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * 광고 ID를 기반으로 광고 세부 정보를 가져오는 커스텀 훅
+ * @param {number | null} id - 조회할 광고의 고유 ID
+ * @returns {AdDetailHookResult} - 광고 세부 정보, 로딩 상태, 오류 메시지를 포함하는 객체
+ */
+export const useAdDetail = (id: number | null): AdDetailHookResult => {
+  const [adDetail, setAdDetail] = useState<AdDetails | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAdDetail = async () => {
+      if (!id) {
+        setError("광고 ID가 유효하지 않습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const result = await adApiService.getAdDetail(id);
+        if (!result) {
+          setError("광고를 찾을 수 없습니다.");
+          setIsLoading(false);
+          return;
+        }
+        setAdDetail(result);
+      } catch (error) {
+        setError("광고를 가져오는 중 오류가 발생했습니다.");
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAdDetail();
+  }, [id]);
+
+  return { adDetail, isLoading, error };
+};

--- a/frontend/src/entities/advertisement/model/types.ts
+++ b/frontend/src/entities/advertisement/model/types.ts
@@ -1,4 +1,5 @@
 import { PaginationMeta } from "../../../shared/api/types";
+import { Device } from "../../device/model/types";
 
 /**
  * 광고 정보를 나타내는 인터페이스
@@ -18,4 +19,12 @@ export interface Ad {
 export interface PaginatedAds {
   items: Ad[];
   paginationMeta: PaginationMeta;
+}
+
+/**
+ * 광고 상세 정보와 관련된 기기 목록을 포함하는 인터페이스
+ */
+export interface AdDetails {
+  adsMetadata: Ad;
+  devices: Device[];
 }

--- a/frontend/src/entities/advertisement/ui/AdDetail.tsx
+++ b/frontend/src/entities/advertisement/ui/AdDetail.tsx
@@ -1,0 +1,66 @@
+import { JSX } from "react";
+import { LabeledValue } from "../../../shared/ui/LabeledValue";
+import { Ad } from "../model/types";
+
+/**
+ * 광고 세부 정보를 표시하는 컴포넌트 Props
+ */
+export interface AdDetailProps {
+  ad: Ad | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * AdDetail 컴포넌트는 광고의 세부 정보를 표시합니다.
+ * @param {AdDetailProps} props - 컴포넌트 Props
+ * @returns {JSX.Element} 광고 세부 정보를 포함하는 JSX 요소
+ */
+export const AdDetail = ({
+  ad,
+  isLoading,
+  error,
+}: AdDetailProps): JSX.Element => {
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!ad) {
+    return <div>No ad details available.</div>;
+  }
+
+  return (
+    <div className="flex justify-between gap-8">
+      <div className="flex flex-col gap-8 w-1/2">
+        <LabeledValue label="광고 ID" value={ad.id.toString()} size="sm" />
+        <LabeledValue label="광고 이름" value={ad.title ?? "없음"} size="sm" />
+        <LabeledValue
+          label="광고 설명"
+          value={ad.description ?? "없음"}
+          size="sm"
+        />
+        <LabeledValue
+          label="생성 날짜"
+          value={ad.createdAt.toLocaleString()}
+          size="sm"
+        />
+        <LabeledValue
+          label="수정 날짜"
+          value={ad.modifiedAt.toLocaleString()}
+          size="sm"
+        />
+      </div>
+      <div className="w-1/2">
+        <img
+          src={ad.originalSignedUrl}
+          alt={ad.title ?? "광고 이미지"}
+          className="w-full h-auto object-cover aspect-[4/3] rounded-lg border border-gray-200"
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/entities/device/model/types.ts
+++ b/frontend/src/entities/device/model/types.ts
@@ -6,5 +6,5 @@ export interface Device {
   deviceName: string;
   regionName: string;
   groupName: string;
-  isActive: boolean;
+  isActive?: boolean;
 }

--- a/frontend/src/entities/device/ui/DeviceList.tsx
+++ b/frontend/src/entities/device/ui/DeviceList.tsx
@@ -1,0 +1,77 @@
+import { JSX } from "react";
+import { Device } from "../model/types";
+
+/**
+ * DeviceList 컴포넌트 Props
+ */
+interface DeviceListProps {
+  devices: Device[];
+}
+
+/**
+ * DeviceList 컴포넌트는 기기 목록을 테이블 형식으로 표시합니다.
+ * @param {DeviceListProps} props - 컴포넌트 Props
+ * @returns {JSX.Element} 기기 목록을 포함하는 JSX 요소
+ */
+export const DeviceList = ({ devices }: DeviceListProps): JSX.Element => {
+  if (!devices || devices.length === 0) {
+    return (
+      <div className="text-center py-4 text-neutral-600 border-t">
+        표시할 디바이스가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto border-t">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-neutral-600 uppercase tracking-wider"
+            >
+              기기 ID
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-neutral-600 uppercase tracking-wider"
+            >
+              리전명
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-neutral-600 uppercase tracking-wider"
+            >
+              그룹명
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-neutral-600 uppercase tracking-wider"
+            >
+              기기 이름
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {devices.map((device) => (
+            <tr key={device.deviceId}>
+              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                {device.deviceId}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-600">
+                {device.regionName}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-600">
+                {device.groupName}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-600">
+                {device.deviceName}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/frontend/src/pages/AdDetailPage.tsx
+++ b/frontend/src/pages/AdDetailPage.tsx
@@ -1,0 +1,58 @@
+import { useParams } from "react-router";
+import { TitleTile } from "../widgets/layout/ui/TitleTile";
+import { MainTile } from "../widgets/layout/ui/MainTile";
+import { AdDetail } from "../entities/advertisement/ui/AdDetail";
+import { useAdDetail } from "../entities/advertisement/api/useAdDetail";
+import { DeviceList } from "../entities/device/ui/DeviceList";
+import { JSX } from "react";
+
+/**
+ * AdDetailPage 컴포넌트는 특정 광고의 세부 정보와 해당 광고가 표시되고 있는 디바이스 목록을 보여줍니다.
+ * @returns {JSX.Element} 광고 세부 정보 페이지를 포함하는 JSX 요소
+ */
+export const AdDetailPage = (): JSX.Element => {
+  const { id } = useParams<{ id: string }>();
+  const parsedId = id ? parseInt(id) : null;
+
+  if (parsedId === null || isNaN(parsedId)) {
+    return <div>광고 ID가 제공되지 않았습니다.</div>;
+  }
+
+  const { adDetail, isLoading, error } = useAdDetail(parsedId);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-8">로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div className="flex justify-center py-8">{error}</div>;
+  }
+
+  if (!adDetail) {
+    return (
+      <div className="flex justify-center py-8">광고를 찾을 수 없습니다.</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-8">
+        <TitleTile title="광고 관리" description="광고 업로드 및 스케줄링" />
+      </div>
+      <div className="mb-2">
+        <MainTile title="광고 세부 정보">
+          <AdDetail
+            ad={adDetail.adsMetadata}
+            isLoading={isLoading}
+            error={error}
+          />
+        </MainTile>
+      </div>
+      <div>
+        <MainTile title="광고가 표시되고 있는 디바이스 목록">
+          <DeviceList devices={adDetail.devices} />
+        </MainTile>
+      </div>
+    </div>
+  );
+};

--- a/mqtt-handler/config/config.go
+++ b/mqtt-handler/config/config.go
@@ -25,10 +25,10 @@ type Config struct {
 func NewConfig() *Config {
 	conf := new(Config)
 
-	conf.Server.Port = getEnv("SERVER_PORT", ":8080")
-	conf.MqttBroker.Url = getEnv("MQTT_BROKER_URL", "tcp://localhost:1883")
-	conf.MqttBroker.ClientId = getEnv("MQTT_CLIENT_ID", "mqtt-handler")
-	conf.QuestDB.Conf = getEnv("QUESTDB_CONF", "http::addr=localhost:9000")
+	conf.Server.Port = getEnv("SERVER_PORT", ":8000")
+	conf.MqttBroker.Url = getEnv("MQTT_BROKER_URL", "tcp://emqx-nlb-bfefab8efb8db52f.elb.ap-northeast-2.amazonaws.com:1883")
+	conf.MqttBroker.ClientId = getEnv("MQTT_CLIENT_ID", "mqtt-handler-junwoo")
+	conf.QuestDB.Conf = getEnv("QUESTDB_CONF", "http::addr=localhost:19000")
 
 	return conf
 }


### PR DESCRIPTION
# Changelog
- `/ads/:id` PATH를 광고 세부 페이지 컴포넌트와 연결하였습니다.
- 광고 세부정보 데이터를 가져오는 `getAdDetail()` 함수를 Advertisement Entity API Service에 추가하였습니다.
- 광고 세부 정보를 가져오는 커스텀 훅 `useAdDetail`을 생성하였습니다.
- `광고 세부 정보 + 현재 광고를 표시중인 기기 목록`을 광고 세부 정보 페이지로 생성하였습니다.

# Testing
<img width="1708" height="1015" alt="image" src="https://github.com/user-attachments/assets/8347590a-568e-43a1-a09f-b19af716cf66" />

# Ops Impact
N/A

# Version Compatibility
N/A