### PR TITLE
[Frontend] 광고 배포 모달창 구현

### DIFF
--- a/frontend/src/entities/advertisement/ui/AdList.tsx
+++ b/frontend/src/entities/advertisement/ui/AdList.tsx
@@ -1,6 +1,7 @@
 import { JSX } from "react";
 import { Ad } from "../model/types";
 import { Link } from "react-router";
+import { CheckCircle, Circle } from "lucide-react";
 
 /**
  * 광고 목록 컴포넌트 Props
@@ -9,19 +10,49 @@ export interface AdListProps {
   ads: Ad[];
   isLoading: boolean;
   error: string | null;
+  isSelectionMode?: boolean;
+  selectedAds?: Ad[];
+  onAdSelect?: (ad: Ad) => void;
 }
 
 /**
  * 개별 광고 카드 컴포넌트
+ * isSelectionMode를 활성화하면 광고를 선택할 수 있는 모드로 변경됩니다.
+ * @param {Object} props - 컴포넌트 props
+ * @param {Ad} props.ad - 광고 객체
+ * @param {boolean} [props.isSelectionMode] - 선택 모드 여부
+ * @param {boolean} [props.isSelected] - 광고가 선택되었는지 여부
+ * @param {(ad: Ad) => void} [props.onSelect] - 광고 선택 시 호출되는 콜백 함수
+ * @returns {JSX.Element} 광고 카드 컴포넌트
  */
-const AdCard = ({ ad }: { ad: Ad }) => {
-  return (
-    <Link
-      to={`/ads/${ad.id}`}
-      className="group block border border-gray-200 rounded-lg overflow-hidden hover:bg-gray-50 hover:shadow-md transition-all duration-200"
-    >
+const AdCard = ({
+  ad,
+  isSelectionMode,
+  isSelected,
+  onSelect,
+}: {
+  ad: Ad;
+  isSelectionMode?: boolean;
+  isSelected?: boolean;
+  onSelect?: (ad: Ad) => void;
+}): JSX.Element => {
+  const cardContent = (
+    <>
+      {isSelectionMode && (
+        <div className="absolute top-2 left-2 z-10 bg-white rounded-full">
+          {isSelected ? (
+            <CheckCircle className="text-blue-600" />
+          ) : (
+            <Circle className="text-gray-400" />
+          )}
+        </div>
+      )}
       {/* 이미지 영역 */}
-      <div className="w-full aspect-[4/3] bg-gray-100 overflow-hidden">
+      <div
+        className={`w-full aspect-[4/3] bg-gray-100 overflow-hidden rounded-t-lg group-hover:opacity-90 transition-opacity ${
+          isSelected ? "ring-2 ring-blue-500" : ""
+        }`}
+      >
         <img
           src={ad.originalSignedUrl}
           alt={ad.title}
@@ -40,6 +71,26 @@ const AdCard = ({ ad }: { ad: Ad }) => {
           </div>
         )}
       </div>
+    </>
+  );
+
+  if (isSelectionMode) {
+    return (
+      <div
+        onClick={() => onSelect?.(ad)}
+        className="relative group block border border-gray-200 rounded-lg overflow-hidden hover:bg-gray-50 hover:shadow-md transition-all duration-200 cursor-pointer"
+      >
+        {cardContent}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={`/ads/${ad.id}`}
+      className="group block border border-gray-200 rounded-lg overflow-hidden hover:bg-gray-50 hover:shadow-md transition-all duration-200"
+    >
+      {cardContent}
     </Link>
   );
 };
@@ -49,7 +100,14 @@ const AdCard = ({ ad }: { ad: Ad }) => {
  * @param {AdListProps} props - 컴포넌트 props
  * @returns {JSX.Element} 광고 목록 컴포넌트
  */
-export const AdList = ({ ads, isLoading, error }: AdListProps): JSX.Element => {
+export const AdList = ({
+  ads,
+  isLoading,
+  error,
+  isSelectionMode = false,
+  selectedAds = [],
+  onAdSelect,
+}: AdListProps): JSX.Element => {
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -78,7 +136,13 @@ export const AdList = ({ ads, isLoading, error }: AdListProps): JSX.Element => {
     <div className="p-4">
       <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {ads.map((ad) => (
-          <AdCard key={ad.id} ad={ad} />
+          <AdCard
+            key={ad.id}
+            ad={ad}
+            isSelectionMode={isSelectionMode}
+            isSelected={selectedAds.some((selected) => selected.id === ad.id)}
+            onSelect={onAdSelect}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/features/ad_deploy/api/api.ts
+++ b/frontend/src/features/ad_deploy/api/api.ts
@@ -7,6 +7,14 @@ import { RegionApiService } from "../../../entities/region/api/regionApi";
 import { GroupApiService } from "../../../entities/group/api/api";
 import { deviceApiService } from "../../../entities/device/api/api";
 
+/**
+ * 광고 배포 요청 인터페이스
+ * - adIds: 배포할 광고 ID 배열
+ * - deploymentType: 배포 유형 (지역, 그룹, 기기)
+ * - regions: 선택된 지역 배열 (선택 사항)
+ * - groups: 선택된 그룹 배열 (선택 사항)
+ * - devices: 선택된 기기 배열 (선택 사항)
+ */
 export interface AdDeployRequest {
   adIds: number[];
   deploymentType: DeploymentType;
@@ -15,19 +23,35 @@ export interface AdDeployRequest {
   devices?: Device[];
 }
 
+/**
+ * 광고를 배포하는 함수
+ * @param {AdDeployRequest} request - 배포 요청 데이터
+ */
 export const deployAds = async (request: AdDeployRequest) => {
   const response = await apiClient.post("/ad-deployments", request);
   return response.data;
 };
 
+/**
+ * API로부터 지역(Region) 데이터를 가져오는 함수
+ * @returns {Promise<Region[]>} 지역 정보 객체의 배열을 반환하는 프로미스
+ */
 export const fetchRegions = async (): Promise<Region[]> => {
   return await RegionApiService.getRegions();
 };
 
+/**
+ * API로부터 그룹(Group) 데이터를 가져오는 함수
+ * @returns {Promise<Group[]>} 그룹 정보 객체의 배열을 반환하는 프로미스
+ */
 export const fetchGroups = async (): Promise<Group[]> => {
   return await GroupApiService.getGroups();
 };
 
+/**
+ * API로부터 디바이스(Device) 데이터를 가져오는 함수
+ * @returns {Promise<Device[]>} 디바이스 정보 객체의 배열을 반환하는 프로미스
+ */
 export const fetchDevices = async (): Promise<Device[]> => {
   return await deviceApiService.getDevices();
 };

--- a/frontend/src/features/ad_deploy/api/api.ts
+++ b/frontend/src/features/ad_deploy/api/api.ts
@@ -1,0 +1,33 @@
+import { apiClient } from "../../../shared/api/client";
+import { Region } from "../../../entities/region/model/types";
+import { Group } from "../../../entities/group/model/types";
+import { Device } from "../../../entities/device/model/types";
+import { DeploymentType } from "../model/types";
+import { RegionApiService } from "../../../entities/region/api/regionApi";
+import { GroupApiService } from "../../../entities/group/api/api";
+import { deviceApiService } from "../../../entities/device/api/api";
+
+export interface AdDeployRequest {
+  adIds: number[];
+  deploymentType: DeploymentType;
+  regions?: Region[];
+  groups?: Group[];
+  devices?: Device[];
+}
+
+export const deployAds = async (request: AdDeployRequest) => {
+  const response = await apiClient.post("/ad-deployments", request);
+  return response.data;
+};
+
+export const fetchRegions = async (): Promise<Region[]> => {
+  return await RegionApiService.getRegions();
+};
+
+export const fetchGroups = async (): Promise<Group[]> => {
+  return await GroupApiService.getGroups();
+};
+
+export const fetchDevices = async (): Promise<Device[]> => {
+  return await deviceApiService.getDevices();
+};

--- a/frontend/src/features/ad_deploy/api/useAdDeploy.tsx
+++ b/frontend/src/features/ad_deploy/api/useAdDeploy.tsx
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import { AdDeployRequest, deployAds } from "./api";
+
+/**
+ * useAdDeploy 훅은 광고 배포 요청을 처리하는 뮤테이션 훅입니다.
+ * @returns {UseMutationResult} 광고 배포 요청을 처리하는 뮤테이션 객체
+ */
+export const useAdDeploy = () => {
+  return useMutation({
+    mutationFn: (request: AdDeployRequest) => deployAds(request),
+  });
+};

--- a/frontend/src/features/ad_deploy/model/types.ts
+++ b/frontend/src/features/ad_deploy/model/types.ts
@@ -1,0 +1,16 @@
+/**
+ * 배포 타입
+ */
+export type DeployCategory = "region" | "group" | "device";
+
+/**
+ * 배포 유형을 나타내는 열거형입니다.
+ * - REGION: 지역 단위 배포
+ * - GROUP: 그룹 단위 배포
+ * - DEVICE: 개별 기기 단위 배포
+ */
+export enum DeploymentType {
+  REGION = "REGION",
+  GROUP = "GROUP",
+  DEVICE = "DEVICE",
+}

--- a/frontend/src/features/ad_deploy/ui/AdDeploy.tsx
+++ b/frontend/src/features/ad_deploy/ui/AdDeploy.tsx
@@ -1,0 +1,340 @@
+import { JSX, useEffect, useState } from "react";
+import { DeployCategory, DeploymentType } from "../model/types";
+import { Region } from "../../../entities/region/model/types";
+import { Device } from "../../../entities/device/model/types";
+import { fetchDevices, fetchGroups, fetchRegions } from "../api/api";
+import { RegionTable } from "./RegionTable";
+import { Group } from "../../../entities/group/model/types";
+import { GroupTable } from "./GroupTable";
+import { DeviceTable } from "./DeviceTable";
+import { Ad } from "../../../entities/advertisement/model/types";
+import { Button } from "../../../shared/ui/Button";
+import { toast } from "react-toastify";
+import { useAdDeploy } from "../api/useAdDeploy";
+
+/**
+ * AdDeploy 컴포넌트의 props
+ */
+export interface AdDeployProps {
+  ads: Ad[];
+  onClose: () => void;
+}
+
+/**
+ * 선택된 항목에 대한 요약 정보를 나타내는 인터페이스
+ */
+interface DeploySummary {
+  message: string;
+  count: number;
+  items: string;
+}
+
+/**
+ * 광고 배포 컴포넌트
+ * 리전, 기기, 그룹별로 광고를 배포할 수 있는 UI를 제공
+ *
+ * @param {AdDeployProps} props - 컴포넌트 props
+ * @return {JSX.Element} 렌더링된 광고 배포 컴포넌트
+ */
+export const AdDeploy = ({ ads, onClose }: AdDeployProps): JSX.Element => {
+  const deployCategories: DeployCategory[] = ["region", "device", "group"];
+
+  const [deployCategory, setDeployCategory] =
+    useState<DeployCategory>("region");
+
+  const [regions, setRegions] = useState<Region[]>([]);
+  const [selectedRegions, setSelectedRegions] = useState<Region[]>([]);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [selectedDevices, setSelectedDevices] = useState<Device[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutateAsync: deployAds } = useAdDeploy();
+
+  const handleCategoryChange = (category: DeployCategory) => {
+    setSelectedRegions([]);
+    setSelectedGroups([]);
+    setSelectedDevices([]);
+    setDeployCategory(category);
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        switch (deployCategory) {
+          case "region":
+            if (regions.length === 0) {
+              const fetchedRegions = await fetchRegions();
+              setRegions(fetchedRegions);
+            }
+            break;
+          case "device":
+            if (devices.length === 0) {
+              const fetchedDevices = await fetchDevices();
+              setDevices(fetchedDevices);
+            }
+            break;
+          case "group":
+            if (groups.length === 0) {
+              const fetchedGroups = await fetchGroups();
+              setGroups(fetchedGroups);
+            }
+            break;
+          default:
+            throw new Error("Invalid deploy category");
+        }
+      } catch (error) {
+        setError(
+          `데이터 로드 중 오류가 발생했습니다: ${
+            error instanceof Error ? error.message : "알 수 없는 오류"
+          }`,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadData();
+  }, [deployCategory]);
+
+  const handleRegionSelection = (region: Region) => {
+    setSelectedRegions((prev) => {
+      if (prev.some((r) => r.regionId === region.regionId)) {
+        return prev.filter((r) => r.regionId !== region.regionId);
+      }
+      return [...prev, region];
+    });
+  };
+
+  const handleGroupSelection = (group: Group) => {
+    setSelectedGroups((prev) => {
+      if (prev.some((g) => g.groupId === group.groupId)) {
+        return prev.filter((g) => g.groupId !== group.groupId);
+      }
+      return [...prev, group];
+    });
+  };
+
+  const handleDeviceSelection = (device: Device) => {
+    setSelectedDevices((prev) => {
+      if (prev.some((d) => d.deviceId === device.deviceId)) {
+        return prev.filter((d) => d.deviceId !== device.deviceId);
+      }
+      return [...prev, device];
+    });
+  };
+
+  const handleSelectAllRegions = (checked: boolean) => {
+    setSelectedRegions(checked ? [...regions] : []);
+  };
+
+  const handleSelectAllGroups = (checked: boolean) => {
+    setSelectedGroups(checked ? [...groups] : []);
+  };
+
+  const handleSelectAllDevices = (checked: boolean) => {
+    setSelectedDevices(checked ? [...devices] : []);
+  };
+
+  const getSelectedSummary = (): DeploySummary => {
+    switch (deployCategory) {
+      case "region":
+        return {
+          message: "선택된 리전",
+          count: selectedRegions.length,
+          items: selectedRegions.map((r) => r.regionName).join(", "),
+        };
+      case "device":
+        return {
+          message: "선택된 기기",
+          count: selectedDevices.length,
+          items: selectedDevices.map((d) => d.deviceName).join(", "),
+        };
+      case "group":
+        return {
+          message: "선택된 그룹",
+          count: selectedGroups.length,
+          items: selectedGroups.map((g) => g.groupName).join(", "),
+        };
+      default:
+        return { message: "선택된 항목", count: 0, items: "" };
+    }
+  };
+
+  const handleDeploy = async () => {
+    if (
+      selectedRegions.length === 0 &&
+      selectedGroups.length === 0 &&
+      selectedDevices.length === 0
+    ) {
+      setError("배포할 대상을 하나 이상 선택해주세요.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const deploymentType =
+        deployCategory === "region"
+          ? DeploymentType.REGION
+          : deployCategory === "group"
+            ? DeploymentType.GROUP
+            : DeploymentType.DEVICE;
+
+      if (onClose) {
+        onClose();
+      }
+
+      await toast.promise(
+        deployAds({
+          adIds: ads.map((ad) => ad.id),
+          deploymentType,
+          regions: selectedRegions,
+          groups: selectedGroups,
+          devices: selectedDevices,
+        }),
+        {
+          pending: "배포 요청 중...",
+          success: "배포 요청이 성공적으로 접수되었습니다.",
+          error: "배포 요청 중 오류가 발생했습니다.",
+        },
+      );
+    } catch (error) {
+      setError(
+        `배포 요청 중 오류가 발생했습니다: ${
+          error instanceof Error ? error.message : "알 수 없는 오류"
+        }`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const summary = getSelectedSummary();
+
+  return (
+    <div className="w-full h-full">
+      <div className="mb-6 text-xl font-normal">광고 배포</div>
+
+      {/* 선택된 광고 미리보기 */}
+      <div className="mb-12 bg-gray-50 rounded-lg p-4">
+        <div className="flex justify-center space-x-4">
+          {Array.from({ length: 3 }).map((_, index) => {
+            const ad = ads[index];
+            return (
+              // NOTE: 광고 ID와 div의 key가 중복되는 걸 방지하기 위해 ad-, placeholder- 와 같이 설정
+              <div
+                key={ad ? `ad-${ad.id}` : `placeholder-${index}`}
+                className="w-48"
+              >
+                <div className="w-full aspect-[4/3] rounded-md shadow-md">
+                  {ad ? (
+                    <img
+                      src={ad.originalSignedUrl}
+                      alt={ad.title}
+                      className="w-full h-full object-cover rounded-md"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-white border-2 border-dashed border-gray-300 rounded-md" />
+                  )}
+                </div>
+                <div className="text-sm mt-2 text-center text-gray-600 truncate">
+                  {ad ? ad.title : "비어있음"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 배포 대상 선택 */}
+      <div>
+        <div className="text-lg font-medium">배포 대상 선택</div>
+        <div className="flex space-x-2 mt-4">
+          {deployCategories.map((category) => (
+            <button
+              key={category}
+              onClick={() => handleCategoryChange(category)}
+              className={`px-4 py-2 rounded-md font-regular transition-colors ${
+                deployCategory === category
+                  ? "bg-slate-900 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {category === "region" && "리전별 배포"}
+              {category === "device" && "기기별 배포"}
+              {category === "group" && "그룹별 배포"}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="my-4 p-3 bg-red-50 text-red-700 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <form className="mt-2">
+          {isLoading ? (
+            <div className="flex justify-center items-center h-40">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            </div>
+          ) : (
+            <div>
+              {deployCategory === "region" && (
+                <RegionTable
+                  regions={regions}
+                  selectedRegions={selectedRegions}
+                  onSelectRegion={handleRegionSelection}
+                  onSelectAll={handleSelectAllRegions}
+                />
+              )}
+              {deployCategory === "group" && (
+                <GroupTable
+                  groups={groups}
+                  selectedGroups={selectedGroups}
+                  onSelectGroup={handleGroupSelection}
+                  onSelectAll={handleSelectAllGroups}
+                />
+              )}
+              {deployCategory === "device" && (
+                <DeviceTable
+                  devices={devices}
+                  selectedDevices={selectedDevices}
+                  onSelectDevice={handleDeviceSelection}
+                  onSelectAll={handleSelectAllDevices}
+                />
+              )}
+            </div>
+          )}
+        </form>
+      </div>
+
+      {/* 배포 요약 */}
+      <div className="bg-gray-50 h-32 p-4 mt-8 rounded-md overflow-y-scroll">
+        <div className="font-normal text-base">배포 요약</div>
+        <br />
+        <p className="text-sm">
+          광고:{" "}
+          <span className="font-medium">
+            {ads.map((ad) => ad.title).join(", ")}
+          </span>
+        </p>
+        <p className="text-sm">
+          {summary.message}: {summary.count ? summary.items : "없음"}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 mt-4">
+        <Button title="취소" variant="secondary" onClick={onClose} />
+        <Button title="배포" variant="primary" onClick={handleDeploy} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/ad_deploy/ui/DeviceTable.tsx
+++ b/frontend/src/features/ad_deploy/ui/DeviceTable.tsx
@@ -1,0 +1,87 @@
+import { JSX } from "react";
+import { Device } from "../../../entities/device/model/types";
+
+/**
+ * Interface for DeviceTable component props
+ * @interface
+ * @property {Device[]} devices - List of devices to display
+ * @property {Device[]} selectedDevices - List of selected devices
+ * @property {(device: Device) => void} onSelectDevice - Callback function to handle device selection
+ * @property {(checked: boolean) => void} onSelectAll - Callback function to handle select all action
+ */
+export interface DeviceTableProps {
+  devices: Device[];
+  selectedDevices: Device[];
+  onSelectDevice: (device: Device) => void;
+  onSelectAll: (checked: boolean) => void;
+}
+
+/**
+ * Device selection table component
+ * Provides a table view of devices with checkboxes for selection.
+ *
+ * @param {DeviceTableProps} props - Props for the DeviceTable component
+ * @returns {JSX.Element} Rendered DeviceTable component
+ */
+export const DeviceTable = ({
+  devices,
+  selectedDevices,
+  onSelectDevice,
+  onSelectAll,
+}: DeviceTableProps): JSX.Element => {
+  return (
+    <div className="mt-4 flex flex-col gap-2">
+      <h4 className="text-md font-normal text-neutral-800">기기 선택</h4>
+      <div className="border rounded-md overflow-y-scroll h-80">
+        <table className="w-full">
+          <thead className="bg-gray-100">
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  className="px-4 py-2"
+                  aria-label="Select all devices"
+                  checked={
+                    devices.length > 0 &&
+                    selectedDevices.length === devices.length
+                  }
+                  onChange={(e) => onSelectAll(e.target.checked)}
+                />
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                기기 이름
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                리전
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                상태
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {devices.map((device) => (
+              <tr key={device.deviceId} className="hover:bg-gray-50">
+                <td className="px-4 py-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedDevices.some(
+                      (d) => d.deviceId === device.deviceId,
+                    )}
+                    onChange={() => onSelectDevice(device)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </td>
+                <td className="px-4 py-2 text-sm">{device.deviceName}</td>
+                <td className="px-4 py-2 text-sm">{device.regionName}</td>
+                <td className="px-4 py-2 text-sm">
+                  {device.isActive ? "활성" : "비활성"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/ad_deploy/ui/GroupTable.tsx
+++ b/frontend/src/features/ad_deploy/ui/GroupTable.tsx
@@ -1,0 +1,84 @@
+import { JSX } from "react";
+import { Group } from "../../../entities/group/model/types";
+
+/**
+ * Interface for GroupTable component props
+ * @interface
+ * @property {Group[]} groups - List of groups to display
+ * @property {Group[]} selectedGroups - List of selected groups
+ * @property {(group: Group) => void} onSelectGroup - Callback function to handle group selection
+ * @property {(checked: boolean) => void} onSelectAll - Callback function to handle select all action
+ */
+export interface GroupTableProps {
+  groups: Group[];
+  selectedGroups: Group[];
+  onSelectGroup: (group: Group) => void;
+  onSelectAll: (checked: boolean) => void;
+}
+
+/**
+ * Group selection table component
+ * Provides a table view of groups with checkboxes for selection.
+ *
+ * @param {GroupTableProps} props - Props for the GroupTable component
+ * @returns {JSX.Element} Rendered GroupTable component
+ */
+export const GroupTable = ({
+  groups,
+  selectedGroups,
+  onSelectGroup,
+  onSelectAll,
+}: GroupTableProps): JSX.Element => {
+  return (
+    <div className="mt-4 flex flex-col gap-2">
+      <h4 className="text-md font-normal text-neutral-800">그룹 선택</h4>
+      <div className="border rounded-md overflow-y-scroll h-80">
+        <table className="w-full">
+          <thead className="bg-gray-100">
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  className="px-4 py-2"
+                  aria-label="Select all groups"
+                  checked={
+                    groups.length > 0 && selectedGroups.length === groups.length
+                  }
+                  onChange={(e) => onSelectAll(e.target.checked)}
+                />
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                그룹 ID
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                그룹명
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                기기 수
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {groups.map((group) => (
+              <tr key={group.groupId} className="hover:bg-gray-50">
+                <td className="px-4 py-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedGroups.some(
+                      (g) => g.groupId === group.groupId,
+                    )}
+                    onChange={() => onSelectGroup(group)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </td>
+                <td className="px-4 py-2 text-sm">{group.groupId}</td>
+                <td className="px-4 py-2 text-sm">{group.groupName}</td>
+                <td className="px-4 py-2 text-sm">{group.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/ad_deploy/ui/RegionTable.tsx
+++ b/frontend/src/features/ad_deploy/ui/RegionTable.tsx
@@ -1,0 +1,85 @@
+import { JSX } from "react";
+import { Region } from "../../../entities/region/model/types";
+
+/**
+ * Interface for RegionTable component props
+ * @interface
+ * @property {Region[]} regions - List of regions to display
+ * @property {Region[]} selectedRegions - List of selected regions
+ * @property {(region: Region) => void} onSelectRegion - Callback function to handle region selection
+ * @property {(checked: boolean) => void} onSelectAll - Callback function to handle select all action
+ */
+export interface RegionTableProps {
+  regions: Region[];
+  selectedRegions: Region[];
+  onSelectRegion: (region: Region) => void;
+  onSelectAll: (checked: boolean) => void;
+}
+
+/**
+ * Region selection table component
+ * Provides a table view of regions with checkboxes for selection.
+ *
+ * @param {RegionTableProps} props - Props for the RegionTable component
+ * @returns {JSX.Element} Rendered RegionTable component
+ */
+export const RegionTable = ({
+  regions,
+  selectedRegions,
+  onSelectRegion,
+  onSelectAll,
+}: RegionTableProps): JSX.Element => {
+  return (
+    <div className="mt-4 flex flex-col gap-2">
+      <h4 className="text-md font-normal text-neutral-800">리전 선택</h4>
+      <div className="border rounded-md overflow-y-scroll h-80">
+        <table className="w-full">
+          <thead className="bg-gray-100">
+            <tr>
+              <th>
+                <input
+                  type="checkbox"
+                  className="px-4 py-2"
+                  aria-label="Select all regions"
+                  checked={
+                    regions.length > 0 &&
+                    selectedRegions.length === regions.length
+                  }
+                  onChange={(e) => onSelectAll(e.target.checked)}
+                />
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                리전 ID
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                리전명
+              </th>
+              <th className="px-4 py-2 text-left text-sm text-gray-500 font-medium">
+                기기 수
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {regions.map((region) => (
+              <tr key={region.regionId} className="hover:bg-gray-50">
+                <td className="px-4 py-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedRegions.some(
+                      (r) => r.regionId === region.regionId,
+                    )}
+                    onChange={() => onSelectRegion(region)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </td>
+                <td className="px-4 py-2 text-sm">{region.regionId}</td>
+                <td className="px-4 py-2 text-sm">{region.regionName}</td>
+                <td className="px-4 py-2 text-sm">{region.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/AdListPage.tsx
+++ b/frontend/src/pages/AdListPage.tsx
@@ -9,6 +9,9 @@ import { Button } from "../shared/ui/Button";
 import { JSX, useState } from "react";
 import ReactModal from "react-modal";
 import { AdRegisterForm } from "../features/ad_register/ui/adRegisterForm";
+import { Ad } from "../entities/advertisement/model/types";
+import { toast } from "react-toastify";
+import { AdDeploy } from "../features/ad_deploy/ui/AdDeploy";
 
 /**
  * 광고 목록 페이지 컴포넌트
@@ -19,6 +22,22 @@ export const AdListPage = (): JSX.Element => {
     useAdSearch();
 
   const [adRegisterModalOpen, setAdRegisterModalOpen] = useState(false);
+  const [isSelectionMode, setIsSelectionMode] = useState(false);
+  const [selectedAds, setSelectedAds] = useState<Ad[]>([]);
+  const [adDeployModalOpen, setAdDeployModalOpen] = useState(false);
+
+  const handleAdSelect = (ad: Ad) => {
+    setSelectedAds((prevSelected) => {
+      if (prevSelected.some((a) => a.id === ad.id)) {
+        return prevSelected.filter((a) => a.id !== ad.id);
+      }
+      if (prevSelected.length < 3) {
+        return [...prevSelected, ad];
+      }
+      toast.warn("최대 3개의 광고만 선택할 수 있습니다.");
+      return prevSelected;
+    });
+  };
 
   const handlePageClick = (event: { selected: number }) => {
     const newPage = event.selected + 1;
@@ -27,6 +46,12 @@ export const AdListPage = (): JSX.Element => {
 
   const pageCount = pagination?.totalPage ?? 0;
   const currentPage = pagination?.page ?? 1;
+
+  const handleCloseDeployModal = () => {
+    setAdDeployModalOpen(false);
+    setIsSelectionMode(false);
+    setSelectedAds([]);
+  };
 
   return (
     <div className="flex flex-col">
@@ -38,7 +63,14 @@ export const AdListPage = (): JSX.Element => {
           title="업로드 된 광고"
           rightElement={<SearchBar onSearch={handleSearch} />}
         >
-          <AdList ads={ads} isLoading={isLoading} error={error} />
+          <AdList
+            ads={ads}
+            isLoading={isLoading}
+            error={error}
+            isSelectionMode={isSelectionMode}
+            selectedAds={selectedAds}
+            onAdSelect={handleAdSelect}
+          />
 
           <div className="flex items-center justify-between mt-6 text-neutral-500">
             {/* Empty div to align pagination & button to the right */}
@@ -61,25 +93,66 @@ export const AdListPage = (): JSX.Element => {
                 breakClassName="px-2"
               />
             )}
-            <Button
-              title="광고 등록"
-              onClick={() => {
-                setAdRegisterModalOpen(true);
-              }}
-            />
+            <div className="flex items-center gap-2">
+              {isSelectionMode ? (
+                <>
+                  <Button
+                    title="취소"
+                    variant="secondary"
+                    onClick={() => {
+                      setIsSelectionMode(false);
+                      setSelectedAds([]);
+                    }}
+                  />
+                  <Button
+                    title={`배포하기 (${selectedAds.length}/3)`}
+                    disabled={selectedAds.length === 0}
+                    onClick={() => {
+                      setAdDeployModalOpen(true);
+                    }}
+                  />
+                </>
+              ) : (
+                <>
+                  <Button
+                    title="광고 등록"
+                    onClick={() => {
+                      setAdRegisterModalOpen(true);
+                    }}
+                  />
+                  <Button
+                    title="배포하기"
+                    variant="secondary"
+                    onClick={() => setIsSelectionMode(true)}
+                  />
+                </>
+              )}
+            </div>
           </div>
         </MainTile>
 
         <ReactModal
           isOpen={adRegisterModalOpen}
           onRequestClose={() => setAdRegisterModalOpen(false)}
-          overlayClassName={"bg-black bg-opacity-50 fixed inset-0"}
+          overlayClassName={"bg-black bg-opacity-50 fixed inset-0 z-50"}
           appElement={document.getElementById("root") || undefined}
           className={
             "bg-white w-1/2 max-w-2xl h-auto max-h-[80vh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 rounded-lg p-6 shadow-xl"
           }
         >
           <AdRegisterForm onClose={() => setAdRegisterModalOpen(false)} />
+        </ReactModal>
+
+        <ReactModal
+          isOpen={adDeployModalOpen}
+          onRequestClose={handleCloseDeployModal}
+          overlayClassName={"bg-black bg-opacity-50 fixed inset-0 z-50"}
+          appElement={document.getElementById("root") || undefined}
+          className={
+            "bg-white w-3/4 max-w-4xl h-auto max-h-[80vh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 rounded-lg p-6 shadow-xl"
+          }
+        >
+          <AdDeploy ads={selectedAds} onClose={handleCloseDeployModal} />
         </ReactModal>
       </div>
     </div>


### PR DESCRIPTION
# Changelog
- `AdListPage` 컴포넌트에 `배포하기` 버튼을 클릭하면 최대 3개의 광고를 체크 표시하여 배포 타깃으로 설정할 수 있도록 구성하였습니다.
- 배포 모달창에 배포 타겟인 광고들의 미리보기를 표시하고, 배포 타겟을 선택할 수 있도록 하였습니다.
- `useAdDeploy` 뮤테이션 + `toast.promise`를 사용하여 배포 요청을 실행하도록 하였습니다.

# Testing
https://github.com/user-attachments/assets/b1039f59-8e8b-4799-85df-a034ddc99909

# Ops Impact
N/A

# Version Compatibility
N/A