### PR TITLE
[Grafana] Grafana 프로비저닝 셋업

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -11,6 +11,7 @@ env:
   ECR_EMQX_REPOSITORY: emqx
   ECR_PRIVATE_CA_REPOSITORY: private-ca
   ECR_MQTT_HANDLER_REPOSITORY: mqtt-handler
+  ECR_GRAFANA_REPOSITORY: grafana
 
 jobs:
   detect-changes-by-component:
@@ -20,6 +21,7 @@ jobs:
       emqx: ${{ steps.filter.outputs.emqx }}
       private_ca: ${{ steps.filter.outputs.private_ca }}
       mqtt-handler: ${{ steps.filter.outputs.mqtt-handler }}
+      grafana: ${{ steps.filter.outputs.grafana }}
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
@@ -34,6 +36,8 @@ jobs:
               - 'private_ca/**'
             mqtt-handler:
               - 'mqtt-handler/**'
+            grafana:
+              - 'grafana/**'
 
   ci-backend-dev:
     needs: [detect-changes-by-component]
@@ -171,6 +175,40 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_MQTT_HANDLER_REPOSITORY:latest
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+    ci-grafana-dev:
+      needs: [detect-changes-by-component]
+      if: ${{ needs.detect-changes-by-component.outputs.grafana == 'true' }}
+      runs-on: ubuntu-latest
+      outputs:
+        tag: ${{ steps.build-image.outputs.tag }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: ${{ env.AWS_REGION }}
+
+        - name: Login to Amazon ECR
+          id: login-ecr
+          uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
+
+        - name: Build, tag, and push image to Amazon ECR
+          id: build-image
+          env:
+            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+            IMAGE_TAG: ${{ github.sha }}
+          run: |
+            docker build -t $ECR_REGISTRY/$ECR_GRAFANA_REPOSITORY:$IMAGE_TAG \
+              -t $ECR_REGISTRY/$ECR_GRAFANA_REPOSITORY:latest \
+              -f grafana/Dockerfile grafana
+            docker push $ECR_REGISTRY/$ECR_GRAFANA_REPOSITORY:$IMAGE_TAG
+            docker push $ECR_REGISTRY/$ECR_GRAFANA_REPOSITORY:latest
+            echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
   terraform-apply:
     needs: [ci-backend-dev, ci-emqx-dev, ci-private-ca-dev, ci-mqtt-handler-dev]
     if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
@@ -201,6 +239,7 @@ jobs:
           EMQX_IMAGE: ${{ needs.ci-emqx-dev.outputs.tag }}
           PRIVATE_CA_IMAGE: ${{ needs.ci-private-ca-dev.outputs.tag }}
           MQTT_HANDLER_IMAGE: ${{ needs.ci-mqtt-handler-dev.outputs.tag }}
+          GRAFANA_IMAGE: ${{ needs.ci-grafana-dev.outputs.tag }}
         run: |
           image_tags=""
           if [ -n "$BACKEND_IMAGE" ]; then
@@ -214,6 +253,9 @@ jobs:
           fi
           if [ -n "$MQTT_HANDLER_IMAGE" ]; then
             image_tags="$image_tags -var mqtt_handler_image_tag=$MQTT_HANDLER_IMAGE"
+          fi
+          if [ -n "$GRAFANA_IMAGE" ]; then
+            image_tags="$image_tags -var grafana_image_tag=$GRAFANA_IMAGE"
           fi
 
           echo "Applying Terraform with images: $image_tags"

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,9 @@
+# Dockerfile
+FROM grafana/grafana-oss:latest
+
+# QuestDB 플러그인 설치
+ENV GF_INSTALL_PLUGINS=questdb-questdb-datasource
+
+# 프로비저닝 및 대시보드 파일 복사
+COPY ./provisioning /etc/grafana/provisioning
+COPY ./dashboards /etc/grafana/dashboards

--- a/grafana/provisioning/dashboards/default.yml
+++ b/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "Default"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/dashboards

--- a/grafana/provisioning/datasources/questdb.yml
+++ b/grafana/provisioning/datasources/questdb.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: QuestDB
+    type: questdb-questdb-datasource
+    jsonData:
+      server: ${QUESTDB_URL}
+      port: ${QUESTDB_PORT}
+      username: ${QUESTDB_USER}
+      tlsMode: disable
+      maxOpenConnections: 100
+      maxIdleConnections: 100
+      maxConnectionLifetime: 14400
+    secureJsonData:
+      password: ${QUESTDB_PASSWORD}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -153,3 +153,43 @@ resource "aws_ecr_lifecycle_policy" "mqtt_handler" {
     }
   EOF
 }
+
+
+resource "aws_ecr_repository" "grafana" {
+  name                 = "grafana"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "iot-cloud-ota-grafana-ecr-repo"
+    Description = "ECR repository for Grafana in iot-cloud-ota"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "grafana" {
+  repository = aws_ecr_repository.grafana.name
+
+  policy = <<-EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Expire untagged images older than 30 days",
+          "selection": {
+            "tagStatus": "untagged",
+            "countType": "sinceImagePushed",
+            "countUnit": "days",
+            "countNumber": 30
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+  EOF
+}

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -53,7 +53,7 @@ resource "aws_ecs_task_definition" "grafana" {
   container_definitions = jsonencode([
     {
       name      = "grafana"
-      image     = "grafana/grafana:latest"
+      image     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.ap-northeast-2.amazonaws.com/grafana:${var.grafana_image_tag}"
       essential = true
 
       portMappings = [
@@ -64,6 +64,10 @@ resource "aws_ecs_task_definition" "grafana" {
         { name = "GF_SECURITY_ALLOW_EMBEDDING", value = "true" },
         { name = "GF_AUTH_ANONYMOUS_ENABLED", value = "true" },
         { name = "GF_AUTH_ANONYMOUS_ORG_ROLE", value = "Viewer" },
+        { name = "QUESTDB_URL", value = aws_instance.questdb.private_ip },
+        { name = "QUESTDB_PORT", value = "8812" },
+        { name = "QUESTDB_USER", value = local.questdb_credentials.username },
+        { name = "QUESTDB_PASSWORD", value = local.questdb_credentials.password },
       ]
 
       logConfiguration = {

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -232,14 +232,14 @@ resource "aws_security_group" "questdb" {
     from_port       = 8812
     to_port         = 8812
     protocol        = "tcp"
-    security_groups = [aws_security_group.bastion_sg.id, aws_security_group.backend.id]
+    security_groups = [aws_security_group.bastion_sg.id, aws_security_group.backend.id, aws_security_group.grafana.id]
   }
 
   ingress {
     from_port       = 9000
     to_port         = 9000
     protocol        = "tcp"
-    security_groups = [aws_security_group.bastion_sg.id, aws_security_group.mqtt_handler.id, ]
+    security_groups = [aws_security_group.bastion_sg.id, aws_security_group.mqtt_handler.id, aws_security_group.grafana.id]
   }
 
   ingress {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,9 @@ variable "mqtt_handler_image_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "grafana_image_tag" {
+  description = "The tag of the Grafana image to use."
+  type        = string
+  default     = "latest"
+}


### PR DESCRIPTION
# Changelog
- Grafana 대시보드 Provisioning 을 구성하였습니다.
  - 일관성 있는 대시보드 환경 구축: Grafana 대시보드를 JSON 파일로 정의하고 Dockerfile을 활용하여, 어디서든 동일한 대시보드를 생성할 수 있도록 자동화했습니다.
- QuestDB 데이터 소스 연동
  - Grafana의 데이터 소스로 QuestDB를 추가하여 데이터를 시각화할 수 있게 되었습니다.
  - 데이터베이스 접속 정보(URL, Port, User, Password)는 환경변수로 안전하게 처리하도록 설정했습니다.
    - 필요한 환경변수: `QUESTDB_URL`, `QUESTDB_PORT`, `QUESTDB_USER`, `QUESTDB_PASSWORD`
- CI/CD 파이프라인 통합
  - 개발 서버 자동 배포: Grafana 관련 변경 사항이 발생하면, CI 파이프라인을 통해 자동으로 개발 서버에 배포되도록 구성하여 개발 효율을 높였습니다.

# Testing
- Grafana에 Data Source 확인
<img width="1396" height="251" alt="image" src="https://github.com/user-attachments/assets/454419d2-e9e6-4266-86f0-c67f801d9e64" />

- Grafana - QuestDB 연결 테스트
<img width="896" height="234" alt="image" src="https://github.com/user-attachments/assets/14e1615a-f7b5-4055-a042-c8613b07934c" />

# Ops Impact
N/A

# Version Compatibility
N/A