### PR TITLE
[Grafana] 펌웨어 다운로드 진행 상태 바 구현

### DIFF
--- a/grafana/dashboards/firmware_download_progress.json
+++ b/grafana/dashboards/firmware_download_progress.json
@@ -1,0 +1,171 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "questdb-questdb-datasource",
+        "uid": "P2596F1C8E12435D2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "super-light-green",
+                "value": 0
+              },
+              {
+                "color": "light-green",
+                "value": 30.0005
+              },
+              {
+                "color": "green",
+                "value": 50
+              },
+              {
+                "color": "semi-dark-green",
+                "value": 70
+              },
+              {
+                "color": "dark-green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/^progress$/",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "questdb-questdb-datasource",
+            "uid": "P2596F1C8E12435D2"
+          },
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "fields": [],
+              "limit": "",
+              "mode": "list",
+              "timeField": ""
+            }
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT\n  progress\nFROM\n  download_events\nWHERE\n  command_id = '${command_id}' AND device_id = '${device_id}' AND status = 'IN_PROGRESS'\nLATEST ON timestamp PARTITION BY device_id;",
+          "refId": "A",
+          "selectedFormat": 2
+        }
+      ],
+      "title": "Firmware Download Progress",
+      "type": "bargauge"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "b787bafe-5a1e-49b0-91f0-892757bcc9ae",
+          "value": "b787bafe-5a1e-49b0-91f0-892757bcc9ae"
+        },
+        "definition": "SELECT DISTINCT command_id FROM download_events;",
+        "description": "",
+        "name": "command_id",
+        "options": [],
+        "query": "SELECT DISTINCT command_id FROM download_events;",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1",
+          "value": "1"
+        },
+        "definition": "SELECT DISTINCT device_id FROM download_events WHERE command_id = '${command_id}';",
+        "description": "",
+        "name": "device_id",
+        "options": [],
+        "query": "SELECT DISTINCT device_id FROM download_events WHERE command_id = '${command_id}';",
+        "refresh": 2,
+        "regex": "",
+        "sort": 3,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Firmware Download Progress",
+  "uid": "659f92f9-5f7c-48b9-9e86-8ae7ed59ca1c",
+  "version": 6
+}

--- a/grafana/dashboards/firmware_download_progress.json
+++ b/grafana/dashboards/firmware_download_progress.json
@@ -88,7 +88,7 @@
         "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [],
+          "calcs": ["mean"],
           "fields": "/^progress$/",
           "values": false
         },
@@ -113,7 +113,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT\n  progress\nFROM\n  download_events\nWHERE\n  command_id = '${command_id}' AND device_id = '${device_id}' AND status = 'IN_PROGRESS'\nLATEST ON timestamp PARTITION BY device_id;",
+          "rawSql": "SELECT progress FROM download_events WHERE command_id = '${command_id}' AND device_id IN (${device_id:csv}) AND status = 'IN_PROGRESS' LATEST ON timestamp PARTITION BY device_id;",
           "refId": "A",
           "selectedFormat": 2
         }
@@ -144,11 +144,14 @@
       },
       {
         "current": {
-          "text": "1",
-          "value": "1"
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
         },
         "definition": "SELECT DISTINCT device_id FROM download_events WHERE command_id = '${command_id}';",
         "description": "",
+        "includeAll": true,
+        "multi": true,
         "name": "device_id",
         "options": [],
         "query": "SELECT DISTINCT device_id FROM download_events WHERE command_id = '${command_id}';",
@@ -169,3 +172,4 @@
   "uid": "659f92f9-5f7c-48b9-9e86-8ae7ed59ca1c",
   "version": 6
 }
+


### PR DESCRIPTION
# Changelog
- 펌웨어 다운로드 진행상태 대시보드를 구현하였습니다.
- `command-id`와 `device-id`을 variables로 받아, 임베딩 시 원하는 배포의 원하는 기기를 가져올 수 있도로 구성하였습니다.

# Testing
<img width="1398" height="224" alt="image" src="https://github.com/user-attachments/assets/710f4b9b-a46a-422a-8e86-5a5d6aef0ee0" />

# Ops Impact
N/A

# Version Compatibility
N/A