### PR TITLE
[Backend] 광고/펌웨어 배포 완료 시 광고/펌웨어 히스토리 저장 로직 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/DeviceAds.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/DeviceAds.java
@@ -3,6 +3,7 @@ package com.coffee_is_essential.iot_cloud_ota.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.OffsetDateTime;
 
@@ -13,6 +14,7 @@ import java.time.OffsetDateTime;
  */
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @Table(name = "device_ads")
 public class DeviceAds {

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/DeviceFirmware.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/DeviceFirmware.java
@@ -7,17 +7,12 @@ import lombok.Setter;
 
 import java.time.OffsetDateTime;
 
-/**
- * DeviceAds 엔티티는 특정 디바이스에 할당된 광고 메타데이터를 나타냅니다.
- * 각 광고는 시작 시간과 종료 시간을 가지며, 현재 활성 상태를 나타내는 플래그도 포함됩니다.
- * 이 엔티티는 디바이스와 광고 메타데이터 간의 다대일 관계를 맺고 있습니다.
- */
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(name = "device_ads")
-public class DeviceAds {
+@Table(name = "device_firmware")
+public class DeviceFirmware {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,8 +22,8 @@ public class DeviceAds {
     private Device device;
 
     @ManyToOne
-    @JoinColumn(name = "ads_id", nullable = false)
-    private AdsMetadata adsMetadata;
+    @JoinColumn(name = "firmware_id", nullable = false)
+    private FirmwareMetadata firmware;
 
     @Column(name = "started_at", columnDefinition = "TIMESTAMP", nullable = false)
     private OffsetDateTime startedAt;
@@ -36,9 +31,9 @@ public class DeviceAds {
     @Column(name = "ended_at", columnDefinition = "TIMESTAMP")
     private OffsetDateTime endedAt;
 
-    public DeviceAds(Device device, AdsMetadata adsMetadata, OffsetDateTime startedAt) {
+    public DeviceFirmware(Device device, FirmwareMetadata firmware, OffsetDateTime startedAt) {
         this.device = device;
-        this.adsMetadata = adsMetadata;
+        this.firmware = firmware;
         this.startedAt = startedAt;
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareDownloadEvents.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareDownloadEvents.java
@@ -17,6 +17,6 @@ public class FirmwareDownloadEvents {
     private Long downloadBytes;
     private double speedKbps;
     private boolean checksumVerified;
-    private double downloadTime;
+    private Long downloadTime;
     private Timestamp timestamp;
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceAdsJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceAdsJpaRepository.java
@@ -1,7 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.entity.ActiveDeviceInfo;
-import com.coffee_is_essential.iot_cloud_ota.entity.AdsMetadata;
 import com.coffee_is_essential.iot_cloud_ota.entity.DeviceAds;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,14 +11,6 @@ import java.util.List;
 
 @Repository
 public interface DeviceAdsJpaRepository extends JpaRepository<DeviceAds, Long> {
-    @Query("""
-                SELECT da.device.id
-                FROM DeviceAds da
-                WHERE da.adsMetadata = :adsMetadata
-                  AND da.endedAt IS NULL
-            """)
-    List<Long> findActiveDevicesByAds(@Param("adsMetadata") AdsMetadata adsMetadata);
-
     @Query("""
                 SELECT new com.coffee_is_essential.iot_cloud_ota.entity.ActiveDeviceInfo(
                     d.id,

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
@@ -132,8 +132,11 @@ public class DeployJudgeScheduler {
 
         if (!completedEvents.isEmpty()) {
             processCompletedEvents(commandId, completedEvents, firmwareDeployment);
-            if ("AD".equals(commandId.split("-")[0])) {
+            String type = commandId.split("-")[0];
+            if ("AD".equals(type)) {
                 deviceService.updateDeviceAds(commandId, completedEvents);
+            } else if ("FW".equals(type)) {
+                deviceService.updateDeviceFirmware(commandId, completedEvents);
             }
         }
 

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
@@ -3,10 +3,7 @@ package com.coffee_is_essential.iot_cloud_ota.service;
 import com.coffee_is_essential.iot_cloud_ota.entity.*;
 import com.coffee_is_essential.iot_cloud_ota.enums.DeploymentStatus;
 import com.coffee_is_essential.iot_cloud_ota.enums.OverallStatus;
-import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareDeploymentDeviceRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.FirmwareDeploymentRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.OverallDeploymentStatusRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.QuestDbRepository;
+import com.coffee_is_essential.iot_cloud_ota.repository.*;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -40,6 +37,7 @@ public class DeployJudgeScheduler {
     private final DeploymentRedisService deploymentRedisService;
     private final EntityManager em;
     private final QuestDbRepository questDbRepository;
+    private final DeviceService deviceService;
 
     private final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
@@ -134,6 +132,9 @@ public class DeployJudgeScheduler {
 
         if (!completedEvents.isEmpty()) {
             processCompletedEvents(commandId, completedEvents, firmwareDeployment);
+            if ("AD".equals(commandId.split("-")[0])) {
+                deviceService.updateDeviceAds(commandId, completedEvents);
+            }
         }
 
         Long size = srt.opsForSet().size(commandId);
@@ -196,7 +197,6 @@ public class DeployJudgeScheduler {
         firmwareDeploymentDeviceRepository.saveAll(list);
         deploymentRedisService.deleteDevices(commandId, completedEvents);
     }
-    
 
     /**
      * 이벤트 상태가 완료 상태(SUCCESS, FAILED, CANCELLED, TIMEOUT)인지 여부를 판별한다.

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -1,15 +1,17 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.entity.Device;
-import com.coffee_is_essential.iot_cloud_ota.entity.Division;
-import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+import com.coffee_is_essential.iot_cloud_ota.entity.*;
+import com.coffee_is_essential.iot_cloud_ota.repository.AdsMetadataJpaRepository;
 import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
 import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
 import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
+import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Service
@@ -18,6 +20,8 @@ public class DeviceService {
     private final RegionJpaRepository regionJpaRepository;
     private final DivisionJpaRepository divisionJpaRepository;
     private final DeviceJpaRepository deviceJpaRepository;
+    private final AdsMetadataJpaRepository adsMetadataJpaRepository;
+    private final EntityManager em;
 
     /**
      * 새로운 디바이스를 생성하고 저장합니다.
@@ -46,5 +50,42 @@ public class DeviceService {
                 .stream()
                 .map(DeviceSummaryResponseDto::from)
                 .toList();
+    }
+
+    /**
+     * 특정 commandId에 대해 완료된 펌웨어 다운로드 이벤트를 기반으로
+     * 각 디바이스의 광고 상태(DeviceAds)를 업데이트합니다.
+     * 기존에 활성화된 광고는 종료 처리하고, 새로운 광고 메타데이터를 기반으로
+     * 새로운 광고 상태를 생성하여 저장합니다.
+     *
+     * @param commandId       펌웨어 배포 명령 식별자
+     * @param completedEvents 완료된 펌웨어 다운로드 이벤트 리스트
+     */
+    @Transactional
+    public void updateDeviceAds(String commandId, List<FirmwareDownloadEvents> completedEvents) {
+        List<AdsMetadata> metadataList = adsMetadataJpaRepository.findByCommandId(commandId);
+        OffsetDateTime now = OffsetDateTime.now();
+
+        for (FirmwareDownloadEvents event : completedEvents) {
+            Long deviceId = event.getDeviceId();
+
+            em.createQuery("""
+                                UPDATE DeviceAds da
+                                SET da.endedAt = :now
+                                WHERE da.device.id = :deviceId
+                                  AND da.endedAt IS NULL
+                            """)
+                    .setParameter("now", now)
+                    .setParameter("deviceId", deviceId)
+                    .executeUpdate();
+
+            for (AdsMetadata ads : metadataList) {
+                DeviceAds newAds = new DeviceAds();
+                newAds.setDevice(em.getReference(Device.class, deviceId));
+                newAds.setAdsMetadata(ads);
+                newAds.setStartedAt(now);
+                em.persist(newAds);
+            }
+        }
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -2,10 +2,7 @@ package com.coffee_is_essential.iot_cloud_ota.service;
 
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.entity.*;
-import com.coffee_is_essential.iot_cloud_ota.repository.AdsMetadataJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.DeviceJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
-import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
+import com.coffee_is_essential.iot_cloud_ota.repository.*;
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +19,7 @@ public class DeviceService {
     private final DeviceJpaRepository deviceJpaRepository;
     private final AdsMetadataJpaRepository adsMetadataJpaRepository;
     private final EntityManager em;
+    private final FirmwareDeploymentRepository firmwareDeploymentRepository;
 
     /**
      * 새로운 디바이스를 생성하고 저장합니다.
@@ -80,12 +78,50 @@ public class DeviceService {
                     .executeUpdate();
 
             for (AdsMetadata ads : metadataList) {
-                DeviceAds newAds = new DeviceAds();
-                newAds.setDevice(em.getReference(Device.class, deviceId));
-                newAds.setAdsMetadata(ads);
-                newAds.setStartedAt(now);
+                DeviceAds newAds = new DeviceAds(
+                        em.getReference(Device.class, deviceId),
+                        ads,
+                        now
+                );
                 em.persist(newAds);
             }
+        }
+    }
+
+    /**
+     * 특정 commandId에 대해 완료된 펌웨어 다운로드 이벤트를 기반으로
+     * 각 디바이스의 펌웨어 상태(DeviceFirmware)를 업데이트합니다.
+     * 기존에 활성화된 펌웨어는 종료 처리하고, 새로운 펌웨어 메타데이터를 기반으로
+     * 새로운 펌웨어 상태를 생성하여 저장합니다.
+     *
+     * @param commandId       펌웨어 배포 명령 식별자
+     * @param completedEvents 완료된 펌웨어 다운로드 이벤트 리스트
+     */
+    @Transactional
+    public void updateDeviceFirmware(String commandId, List<FirmwareDownloadEvents> completedEvents) {
+        FirmwareDeployment deployment = firmwareDeploymentRepository.findByCommandIdOrElseThrow(commandId);
+        FirmwareMetadata firmware = deployment.getFirmwareMetadata();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        for (FirmwareDownloadEvents event : completedEvents) {
+            Long deviceId = event.getDeviceId();
+
+            em.createQuery("""
+                                UPDATE DeviceFirmware df
+                                SET df.endedAt = :now
+                                WHERE df.device.id = :deviceId
+                                  AND df.endedAt IS NULL
+                            """)
+                    .setParameter("now", now)
+                    .setParameter("deviceId", deviceId)
+                    .executeUpdate();
+
+            DeviceFirmware newFirmware = new DeviceFirmware(
+                    em.getReference(Device.class, deviceId),
+                    firmware,
+                    now
+            );
+            em.persist(newFirmware);
         }
     }
 }


### PR DESCRIPTION
# Changelog

- 기기별 광고 히스토리를 저장하는 `device_ads` 테이블 추가
- 기기별 펌웨어 히스토리를 저장하는 `device_firmware` 테이블 추가
- 광고 배포 완료 시 `device_ads` 테이블에 광고 이력 업데이트/삽입 로직 추가
- 펌웨어 배포 완료 시 `device_firmware` 테이블에 광고 이력 업데이트/삽입 로직 추가
  - 기존 활성 광고/펌웨어 (ended_at IS NULL) → `ended_at` 현재 시간으로 업데이트
  - 새로운 광고/펌웨어 → started_at = now() 로 삽입

# Testing

- 로컬 환경에서 광고/펌웨어 배포 완료 후 테이블 업데이트 확인
- 기기별 광고 히스토리를 저장하는 `device_ads` 테이블
<img width="940" height="211" alt="image" src="https://github.com/user-attachments/assets/6bb01869-10a7-4acc-a9e8-a86be3f6707c" />

- 기기별 펌웨어 히스토리를 저장하는 `device_firmware` 테이블
<img width="928" height="109" alt="image" src="https://github.com/user-attachments/assets/a5f6e0b3-8e14-411e-9b18-c2a931b4835f" />

# Ops Impact

N/A

# Version Compatibility

N/A