### PR TITLE
[Backend] 기기 관리 페이지 API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
@@ -1,5 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DeviceResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DeviceService;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,8 +31,21 @@ public class DeviceController {
      */
     @GetMapping
     public ResponseEntity<List<DeviceSummaryResponseDto>> findDeviceSummary() {
-        List<DeviceSummaryResponseDto> list = deviceService.findDeviceSummary();
+        List<DeviceSummaryResponseDto> responseDtos = deviceService.findDeviceSummary();
 
-        return new ResponseEntity<>(list, HttpStatus.OK);
+        return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<DeviceResponseDto>> findAllDevices(
+            @RequestParam(required = false) Long regionId,
+            @RequestParam(required = false) Long groupId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        PaginationInfo paginationInfo = PaginationInfo.of(page, limit);
+        List<DeviceResponseDto> responseDtos = deviceService.findAllDevices(regionId, groupId, paginationInfo);
+
+        return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
@@ -1,16 +1,14 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DeviceDetailResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DeviceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -36,6 +34,16 @@ public class DeviceController {
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 
+    /**
+     * 디바이스 목록을 조회합니다.
+     * 선택적으로 regionId와 groupId로 필터링할 수 있으며, 페이지네이션을 지원합니다.
+     *
+     * @param regionId (선택 사항) 필터링할 리전 ID
+     * @param groupId  (선택 사항) 필터링할 그룹 ID
+     * @param page     (기본값: 1) 조회할 페이지 번호
+     * @param limit    (기본값: 10) 페이지당 조회할 디바이스 수
+     * @return 필터링 및 페이지네이션된 디바이스 목록과 HTTP 200 응답
+     */
     @GetMapping("/list")
     public ResponseEntity<DeviceListResponseDto> findAllDevices(
             @RequestParam(required = false) Long regionId,
@@ -45,6 +53,21 @@ public class DeviceController {
     ) {
         PaginationInfo paginationInfo = PaginationInfo.of(page, limit);
         DeviceListResponseDto responseDto = deviceService.findAllDevices(regionId, groupId, paginationInfo);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    /**
+     * 특정 디바이스의 상세 정보를 조회합니다.
+     * 디바이스의 상세 정보에는 디바이스 아이디, 디바이스 이름, 리전 이름, 그룹 이름, 활성화 상태 여부,
+     * 마지막 연결 시간, 펌웨어 버전, IP 주소, MAC 주소를 포함합니다.
+     *
+     * @param id 조회할 디바이스의 ID
+     * @return 디바이스 상세 정보를 담은 DeviceDetailResponseDto와 HTTP 200 응답
+     */
+    @GetMapping("{id}")
+    public ResponseEntity<DeviceDetailResponseDto> findDetailByDeviceId(@PathVariable Long id) {
+        DeviceDetailResponseDto responseDto = deviceService.findDetailByDeviceId(id);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
@@ -1,7 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
-import com.coffee_is_essential.iot_cloud_ota.dto.DeviceResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.DeviceListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DeviceService;
 import lombok.RequiredArgsConstructor;
@@ -37,15 +37,15 @@ public class DeviceController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<DeviceResponseDto>> findAllDevices(
+    public ResponseEntity<DeviceListResponseDto> findAllDevices(
             @RequestParam(required = false) Long regionId,
             @RequestParam(required = false) Long groupId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int limit
     ) {
         PaginationInfo paginationInfo = PaginationInfo.of(page, limit);
-        List<DeviceResponseDto> responseDtos = deviceService.findAllDevices(regionId, groupId, paginationInfo);
+        DeviceListResponseDto responseDto = deviceService.findAllDevices(regionId, groupId, paginationInfo);
 
-        return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
@@ -2,7 +2,6 @@ package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionListResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.DivisionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DivisionService;
 import lombok.RequiredArgsConstructor;
@@ -54,8 +53,8 @@ public class DivisionController {
             @RequestParam(required = false) String search
     ) {
         PaginationInfo paginationInfo = new PaginationInfo(page, limit, search);
-        DivisionListResponseDto responseDtos = divisionService.findAllDivisions(paginationInfo);
+        DivisionListResponseDto responseDto = divisionService.findAllDivisions(paginationInfo);
 
-        return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
@@ -1,5 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DivisionListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DivisionService;
@@ -8,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -16,7 +19,7 @@ import java.util.List;
  * 펌웨어 그룹 관련 요청을 처리하는 REST 컨트롤러 입니다.
  */
 @RestController
-@RequestMapping("/api/divisions")
+@RequestMapping("/api/groups")
 @RequiredArgsConstructor
 public class DivisionController {
     private final DivisionService divisionService;
@@ -34,10 +37,25 @@ public class DivisionController {
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
+
+    /**
+     * 전체 그룹의 상세 정보를 페이지네이션하여 조회합니다.
+     * 각 그룹에는 몇 개의 디바이스가 등록되어 있는지를 포함한 정보가 반환됩니다.
+     *
+     * @param page   조회할 페이지 번호 (기본값: 1)
+     * @param limit  페이지당 항목 수 (기본값: 10)
+     * @param search 검색어 (선택 사항) - 그룹 코드 또는 그룹 이름을 기준으로 검색
+     * @return 페이징된 그룹 상세 정보 목록과 페이지 정보가 포함된 응답 DTO와 HTTP 200 OK 응답
+     */
     @GetMapping("/list")
-    public ResponseEntity<List<DivisionResponseDto>> getAllDivisions() {
-        List<DivisionResponseDto> responseDtos = divisionService.findAllDivisions();
+    public ResponseEntity<DivisionListResponseDto> getAllDivisions(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(required = false) String search
+    ) {
+        PaginationInfo paginationInfo = new PaginationInfo(page, limit, search);
+        DivisionListResponseDto responseDtos = divisionService.findAllDivisions(paginationInfo);
+
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
-
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DivisionController.java
@@ -1,5 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.dto.DivisionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.DivisionService;
 import lombok.RequiredArgsConstructor;
@@ -32,4 +33,11 @@ public class DivisionController {
 
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<DivisionResponseDto>> getAllDivisions() {
+        List<DivisionResponseDto> responseDtos = divisionService.findAllDivisions();
+        return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+    }
+
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
@@ -2,7 +2,6 @@ package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionListResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.RegionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.RegionService;
 import lombok.RequiredArgsConstructor;
@@ -53,8 +52,8 @@ public class RegionController {
             @RequestParam(required = false) String search
     ) {
         PaginationInfo paginationInfo = new PaginationInfo(page, limit, search);
-        RegionListResponseDto responseDtos = regionService.findAllRegions(paginationInfo);
+        RegionListResponseDto responseDto = regionService.findAllRegions(paginationInfo);
 
-        return new ResponseEntity(responseDtos, HttpStatus.OK);
+        return new ResponseEntity(responseDto, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
@@ -1,5 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.RegionService;
@@ -8,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -35,13 +38,22 @@ public class RegionController {
     }
 
     /**
-     * 전체 리전의 상세 정보를 조회합니다.
+     * 전체 리전의 상세 정보를 페이지네이션하여 조회합니다.
+     * 각 리전에는 몇 개의 디바이스가 등록되어 있는지를 포함한 정보가 반환됩니다.
      *
-     * @return 리전 ID, 리전 코드, 리전 이름을 포함한 리스트와 HTTP 200 OK 응답
+     * @param page   조회할 페이지 번호 (기본값: 1)
+     * @param limit  페이지당 항목 수 (기본값: 10)
+     * @param search 검색어 (선택 사항) - 리전 코드 또는 리전 이름을 기준으로 검색
+     * @return 페이징된 리전 상세 정보 목록과 페이지 정보가 포함된 응답 DTO와 HTTP 200 OK 응답
      */
     @GetMapping("/list")
-    public ResponseEntity<RegionResponseDto> findAllRegions() {
-        List<RegionResponseDto> responseDtos = regionService.findAllRegions();
+    public ResponseEntity<RegionListResponseDto> findAllRegions(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(required = false) String search
+    ) {
+        PaginationInfo paginationInfo = new PaginationInfo(page, limit, search);
+        RegionListResponseDto responseDtos = regionService.findAllRegions(paginationInfo);
 
         return new ResponseEntity(responseDtos, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/RegionController.java
@@ -1,5 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.service.RegionService;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +32,17 @@ public class RegionController {
         List<RegionSummaryResponseDto> list = regionService.findRegionSummary();
 
         return new ResponseEntity<>(list, HttpStatus.OK);
+    }
+
+    /**
+     * 전체 리전의 상세 정보를 조회합니다.
+     *
+     * @return 리전 ID, 리전 코드, 리전 이름을 포함한 리스트와 HTTP 200 OK 응답
+     */
+    @GetMapping("/list")
+    public ResponseEntity<RegionResponseDto> findAllRegions() {
+        List<RegionResponseDto> responseDtos = regionService.findAllRegions();
+
+        return new ResponseEntity(responseDtos, HttpStatus.OK);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsResponseDto.java
@@ -1,0 +1,11 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.time.OffsetDateTime;
+
+public record AdsResponseDto(
+        Long id,
+        String title,
+        OffsetDateTime deployedAt,
+        String originalSignedUrl
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailDivisionDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailDivisionDto.java
@@ -1,0 +1,13 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+
+public record DeviceDetailDivisionDto(
+        Long id,
+        String code,
+        String name
+) {
+    public static DeviceDetailDivisionDto from(Division division) {
+        return new DeviceDetailDivisionDto(division.getId(), division.getDivisionCode(), division.getDivisionName());
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailRegionDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailRegionDto.java
@@ -1,0 +1,14 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+
+public record DeviceDetailRegionDto(
+        Long id,
+        String code,
+        String name
+) {
+    public static DeviceDetailRegionDto from(Region region) {
+
+        return new DeviceDetailRegionDto(region.getId(), region.getRegionCode(), region.getRegionName());
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailResponseDto.java
@@ -1,0 +1,17 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record DeviceDetailResponseDto(
+        Long deviceId,
+        String deviceName,
+        OffsetDateTime createdAt,
+        OffsetDateTime modifiedAt,
+        OffsetDateTime lastActiveAt,
+        DeviceDetailRegionDto region,
+        DeviceDetailDivisionDto group,
+        FirmwareResponseDto firmware,
+        List<AdsResponseDto> advertisements
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceListResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceListResponseDto.java
@@ -1,0 +1,12 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.util.List;
+
+public record DeviceListResponseDto(
+        List<DeviceResponseDto> items,
+        PaginationMetadataDto paginationMeta
+) {
+    public static DeviceListResponseDto of(List<DeviceResponseDto> items, PaginationMetadataDto paginationMeta) {
+        return new DeviceListResponseDto(items, paginationMeta);
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceResponseDto.java
@@ -6,8 +6,8 @@ public record DeviceResponseDto(
         Long deviceId,
         String deviceName,
         OffsetDateTime createdAt,
-        RegionResponseDto region,
-        DivisionResponseDto group,
-        OffsetDateTime lastActive
+        String regionName,
+        String groupName,
+        OffsetDateTime lastActiveAt
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceResponseDto.java
@@ -1,0 +1,13 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.time.OffsetDateTime;
+
+public record DeviceResponseDto(
+        Long deviceId,
+        String deviceName,
+        OffsetDateTime createdAt,
+        RegionResponseDto region,
+        DivisionResponseDto group,
+        OffsetDateTime lastActive
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionListResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionListResponseDto.java
@@ -1,0 +1,28 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record DivisionListResponseDto(
+        List<DivisionResponseDto> divisions,
+        PaginationMetadataDto paginationMeta
+) {
+    public static DivisionListResponseDto from(Page<Division> divisionPage) {
+        PaginationMetadataDto metadataDto = new PaginationMetadataDto(
+                divisionPage.getPageable().getPageNumber() + 1,
+                divisionPage.getPageable().getPageSize(),
+                divisionPage.getTotalPages(),
+                divisionPage.getTotalElements()
+        );
+
+        return new DivisionListResponseDto(
+                divisionPage.getContent()
+                        .stream()
+                        .map(DivisionResponseDto::from)
+                        .toList(),
+                metadataDto
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionListResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionListResponseDto.java
@@ -6,23 +6,17 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public record DivisionListResponseDto(
-        List<DivisionResponseDto> divisions,
+        List<DivisionResponseDto> items,
         PaginationMetadataDto paginationMeta
 ) {
     public static DivisionListResponseDto from(Page<Division> divisionPage) {
-        PaginationMetadataDto metadataDto = new PaginationMetadataDto(
-                divisionPage.getPageable().getPageNumber() + 1,
-                divisionPage.getPageable().getPageSize(),
-                divisionPage.getTotalPages(),
-                divisionPage.getTotalElements()
-        );
 
         return new DivisionListResponseDto(
                 divisionPage.getContent()
                         .stream()
                         .map(DivisionResponseDto::from)
                         .toList(),
-                metadataDto
+                PaginationMetadataDto.from(divisionPage)
         );
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
@@ -1,20 +1,12 @@
 package com.coffee_is_essential.iot_cloud_ota.dto;
 
 import com.coffee_is_essential.iot_cloud_ota.entity.Division;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class DivisionResponseDto {
-    @JsonProperty("groupId")
-    private Long id;
-    @JsonProperty("groupCode")
-    private String code;
-    @JsonProperty("groupName")
-    private String name;
-
+public record DivisionResponseDto(
+        Long groupId,
+        String groupCode,
+        String groupName
+) {
     public static DivisionResponseDto from(Division d) {
         return new DivisionResponseDto(d.getId(), d.getDivisionCode(), d.getDivisionName());
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
@@ -1,0 +1,21 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DivisionResponseDto {
+    @JsonProperty("groupId")
+    private Long id;
+    @JsonProperty("groupCode")
+    private String code;
+    @JsonProperty("groupName")
+    private String name;
+
+    public static DivisionResponseDto from(Division d) {
+        return new DivisionResponseDto(d.getId(), d.getDivisionCode(), d.getDivisionName());
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DivisionResponseDto.java
@@ -7,7 +7,7 @@ public record DivisionResponseDto(
         String groupCode,
         String groupName
 ) {
-    public static DivisionResponseDto from(Division d) {
-        return new DivisionResponseDto(d.getId(), d.getDivisionCode(), d.getDivisionName());
+    public static DivisionResponseDto from(Division division) {
+        return new DivisionResponseDto(division.getId(), division.getDivisionCode(), division.getDivisionName());
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareDeploymentDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareDeploymentDto.java
@@ -8,10 +8,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public record FirmwareDeploymentDto(
-//        String signedUrl,
-//        FirmwareDeployInfo fileInfo,
-//        List<DeployTargetDeviceInfo> devices,
-//        int timeout
         @JsonProperty("command_id")
         String commandId,
         DeploymentContent content,

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/FirmwareResponseDto.java
@@ -1,0 +1,15 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.DeviceFirmware;
+
+public record FirmwareResponseDto(
+        Long id,
+        String version
+) {
+    public static FirmwareResponseDto from(DeviceFirmware deviceFirmware) {
+        return new FirmwareResponseDto(
+                deviceFirmware.getFirmware().getId(),
+                deviceFirmware.getFirmware().getVersion()
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/PaginationMetadataDto.java
@@ -1,5 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.dto;
 
+import org.springframework.data.domain.Page;
+
 /**
  * 페이지네이션에 대한 메타데이터 정보를 포한한 DTO 입니다.
  *
@@ -14,4 +16,12 @@ public record PaginationMetadataDto(
         int totalPage,
         long totalCount
 ) {
+    public static PaginationMetadataDto from(Page<?> pageData) {
+        return new PaginationMetadataDto(
+                pageData.getPageable().getPageNumber() + 1,
+                pageData.getPageable().getPageSize(),
+                pageData.getTotalPages(),
+                pageData.getTotalElements()
+        );
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionListResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionListResponseDto.java
@@ -1,0 +1,22 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record RegionListResponseDto(
+        List<RegionResponseDto> items,
+        PaginationMetadataDto paginationMeta
+) {
+    public static RegionListResponseDto from(Page<Region> regionPage) {
+
+        return new RegionListResponseDto(
+                regionPage.getContent()
+                        .stream()
+                        .map(RegionResponseDto::from)
+                        .toList(),
+                PaginationMetadataDto.from(regionPage)
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionResponseDto.java
@@ -7,8 +7,8 @@ public record RegionResponseDto(
         String regionCode,
         String regionName
 ) {
-    public static RegionResponseDto from(Region r) {
+    public static RegionResponseDto from(Region region) {
 
-        return new RegionResponseDto(r.getId(), r.getRegionCode(), r.getRegionName());
+        return new RegionResponseDto(region.getId(), region.getRegionCode(), region.getRegionName());
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/RegionResponseDto.java
@@ -1,0 +1,14 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+
+public record RegionResponseDto(
+        Long regionId,
+        String regionCode,
+        String regionName
+) {
+    public static RegionResponseDto from(Region r) {
+
+        return new RegionResponseDto(r.getId(), r.getRegionCode(), r.getRegionName());
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Device.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Device.java
@@ -43,4 +43,16 @@ public class Device extends BaseEntity {
     public Long getRegionId() {
         return region.getId();
     }
+
+    public String getName() {
+        return name;
+    }
+
+    public Division getDivision() {
+        return division;
+    }
+
+    public Region getRegion() {
+        return region;
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareDeployment.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/FirmwareDeployment.java
@@ -43,7 +43,7 @@ public class FirmwareDeployment extends BaseEntity {
 
     public FirmwareDeployment(String commandId, DeploymentType deploymentType, OffsetDateTime deployedAt, OffsetDateTime expiresAt) {
         this.commandId = commandId;
-        this.deploymentType = deploymentType;
+        this.deploymentType = deploymentType.name().equals("GROUP") ? DeploymentType.DIVISION : deploymentType;
         this.deployedAt = deployedAt;
         this.expiresAt = expiresAt;
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/SystemStatus.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/SystemStatus.java
@@ -1,0 +1,18 @@
+package com.coffee_is_essential.iot_cloud_ota.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+public class SystemStatus {
+    private Long deviceId;
+    private double cpuCore0;
+    private double cpuCore1;
+    private double memoryUsage;
+    private double storageUsage;
+    private Long uptime;
+    private OffsetDateTime timestamp;
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/AdsMetadataJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/AdsMetadataJpaRepository.java
@@ -7,13 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 public interface AdsMetadataJpaRepository extends JpaRepository<AdsMetadata, Long> {
     Optional<AdsMetadata> findByTitle(String title);
 

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceAdsJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceAdsJpaRepository.java
@@ -5,11 +5,9 @@ import com.coffee_is_essential.iot_cloud_ota.entity.DeviceAds;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface DeviceAdsJpaRepository extends JpaRepository<DeviceAds, Long> {
     @Query("""
                 SELECT new com.coffee_is_essential.iot_cloud_ota.entity.ActiveDeviceInfo(
@@ -27,5 +25,7 @@ public interface DeviceAdsJpaRepository extends JpaRepository<DeviceAds, Long> {
                   AND da.endedAt IS NULL
             """)
     List<ActiveDeviceInfo> findActiveDevicesByAdsId(@Param("adsId") Long adsId);
+
+    List<DeviceAds> findByDeviceIdAndEndedAtIsNull(Long deviceId);
 }
 

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceFirmwareJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceFirmwareJpaRepository.java
@@ -1,0 +1,10 @@
+package com.coffee_is_essential.iot_cloud_ota.repository;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.DeviceFirmware;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceFirmwareJpaRepository extends JpaRepository<DeviceFirmware, Long> {
+    Optional<DeviceFirmware> findByDeviceIdAndEndedAtIsNull(Long deviceId);
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceJpaRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -47,4 +49,8 @@ public interface DeviceJpaRepository extends JpaRepository<Device, Long>, Device
     Page<Device> findByRegionAndGroup(@Param("regionId") Long regionId,
                                       @Param("groupId") Long groupId,
                                       Pageable pageable);
+
+    default Device findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "[ID: " + id + "] 기기를 찾을 수 없습니다."));
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceJpaRepository.java
@@ -2,8 +2,11 @@ package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.DeviceSummary;
 import com.coffee_is_essential.iot_cloud_ota.entity.Device;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -28,22 +31,20 @@ public interface DeviceJpaRepository extends JpaRepository<Device, Long>, Device
     List<DeviceSummary> findDeviceSummary();
 
     /**
-     * 주어진 디바이스 ID 목록에 해당하는 디바이스의 요약 정보를 조회합니다.
-     * 디바이스 ID, 디바이스 이름, 지역 이름, 그룹 이름을 포함한 정보를 {@link DeviceSummary} 형태로 반환합니다.
+     * 리전 ID와 그룹 ID에 따라 디바이스를 필터링하여 페이징된 결과를 조회합니다.
+     * 리전 ID 또는 그룹 ID가 null인 경우 해당 조건은 무시됩니다.
      *
-     * @param deviceIds 조회할 디바이스 ID 목록
-     * @return 디바이스 요약 정보 리스트 {@link DeviceSummary}
+     * @param regionId 리전 ID (null 가능)
+     * @param groupId  그룹 ID (null 가능)
+     * @param pageable 페이징 정보
+     * @return 필터링된 디바이스의 페이징된 결과
      */
-    @Query(value = """
-            SELECT
-            de.id AS deviceId,
-            de.name AS deviceName,
-            r.region_name AS regionName,
-            di.division_name AS groupName
-            FROM device de
-            JOIN region r ON de.region_id = r.id
-            JOIN division di ON de.division_id = di.id
-            WHERE de.id IN :deviceIds
-            """, nativeQuery = true)
-    List<DeviceSummary> findDeviceSummaryByIdIn(List<Long> deviceIds);
+    @Query("""
+            SELECT d FROM Device d
+            WHERE (:regionId IS NULL OR d.region.id = :regionId)
+              AND (:groupId IS NULL OR d.division.id = :groupId)
+            """)
+    Page<Device> findByRegionAndGroup(@Param("regionId") Long regionId,
+                                      @Param("groupId") Long groupId,
+                                      Pageable pageable);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceStatusJdbcRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DeviceStatusJdbcRepository.java
@@ -1,0 +1,64 @@
+package com.coffee_is_essential.iot_cloud_ota.repository;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.SystemStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DeviceStatusJdbcRepository {
+    private final @Qualifier("questDbJdbcTemplate") JdbcTemplate jdbcTemplate;
+    private final @Qualifier("questDbNamedJdbc") NamedParameterJdbcTemplate namedJdbc;
+
+    /**
+     * 주어진 deviceId에 해당하는 시스템 상태 정보 중
+     * 가장 최신의 상태 정보를 조회합니다.
+     *
+     * @param deviceId 조회할 대상 device_id
+     * @return 가장 최신의 시스템 상태 정보
+     */
+    public SystemStatus findLatestByDeviceId(Long deviceId) {
+        String sql = """
+                SELECT *
+                FROM system_status
+                WHERE device_id = ?
+                ORDER BY "timestamp" DESC
+                LIMIT 1
+                """;
+        List<SystemStatus> results = jdbcTemplate.query(sql, mapper, deviceId);
+
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    /**
+     * 주어진 deviceId 목록에 해당하는 시스템 상태 정보 중
+     * 디바이스별 최신 상태 정보를 조회합니다.
+     *
+     * @param deviceIds 조회할 대상 device_id 목록
+     * @return 디바이스별 최신 시스템 상태 정보 리스트
+     */
+    private final RowMapper<SystemStatus> mapper = new RowMapper<>() {
+        @Override
+        public SystemStatus mapRow(ResultSet rs, int rowNum) throws SQLException {
+            SystemStatus status = new SystemStatus();
+            status.setDeviceId(rs.getLong("device_id"));
+            status.setCpuCore0(rs.getDouble("cpu_core_0"));
+            status.setCpuCore1(rs.getDouble("cpu_core_1"));
+            status.setMemoryUsage(rs.getDouble("memory_usage"));
+            status.setStorageUsage(rs.getDouble("storage_usage"));
+            status.setUptime(rs.getLong("uptime"));
+            status.setTimestamp(rs.getObject("timestamp", OffsetDateTime.class));
+
+            return status;
+        }
+    };
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DivisionJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DivisionJpaRepository.java
@@ -2,6 +2,8 @@ package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.DivisionSummary;
 import com.coffee_is_essential.iot_cloud_ota.entity.Division;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.http.HttpStatus;
@@ -37,4 +39,22 @@ public interface DivisionJpaRepository extends JpaRepository<Division, Long> {
             ORDER BY di.id;
             """, nativeQuery = true)
     List<DivisionSummary> findDivisionSummary();
+
+    /**
+     * 키워드로 디비전을 검색합니다.
+     * 키워드가 null이거나 빈 문자열인 경우 모든 디비전을 반환합니다.
+     * 그렇지 않으면 divisionCode 또는 divisionName에 키워드가 포함된 디비전을 반환합니다.
+     *
+     * @param keyword  검색 키워드 (null 또는 빈 문자열 가능)
+     * @param pageable 페이지네이션 정보
+     * @return 검색된 디비전의 페이지
+     */
+    @Query("""
+            SELECT d
+            FROM Division d
+            WHERE (:keyword IS NULL OR :keyword = '' OR
+                   d.divisionCode LIKE %:keyword% OR
+                   d.divisionName LIKE %:keyword%)
+            """)
+    Page<Division> searchWithNullableKeyword(String keyword, Pageable pageable);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DownloadEventsJdbcRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DownloadEventsJdbcRepository.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
-public class QuestDbRepository {
+public class DownloadEventsJdbcRepository {
     private final @Qualifier("questDbJdbcTemplate") JdbcTemplate jdbcTemplate;
     private final @Qualifier("questDbNamedJdbc") NamedParameterJdbcTemplate namedJdbc;
 

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/RegionJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/RegionJpaRepository.java
@@ -2,6 +2,8 @@ package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.RegionSummary;
 import com.coffee_is_essential.iot_cloud_ota.entity.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.http.HttpStatus;
@@ -37,4 +39,22 @@ public interface RegionJpaRepository extends JpaRepository<Region, Long> {
             ORDER BY r.id;
             """, nativeQuery = true)
     List<RegionSummary> findRegionSummary();
+
+    /**
+     * 키워드로 리전을 검색합니다.
+     * 키워드가 null이거나 빈 문자열인 경우 모든 리전을 반환합니다.
+     * 그렇지 않으면 regionCode 또는 regionName에 키워드가 포함된 리전을 반환합니다.
+     *
+     * @param keyword  검색 키워드 (null 또는 빈 문자열 가능)
+     * @param pageable 페이지네이션 정보
+     * @return 검색된 리전의 페이지
+     */
+    @Query("""
+            SELECT r
+            FROM Region r
+            WHERE (:keyword IS NULL OR :keyword = '' OR
+                   r.regionCode LIKE %:keyword% OR
+                   r.regionName LIKE %:keyword%)
+            """)
+    Page<Region> searchWithNullableKeyword(String keyword, Pageable pageable);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
@@ -36,7 +36,7 @@ public class DeployJudgeScheduler {
     private final OverallDeploymentStatusRepository overallDeploymentStatusRepository;
     private final DeploymentRedisService deploymentRedisService;
     private final EntityManager em;
-    private final QuestDbRepository questDbRepository;
+    private final DownloadEventsJdbcRepository downloadEventsJdbcRepository;
     private final DeviceService deviceService;
 
     private final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
@@ -125,7 +125,7 @@ public class DeployJudgeScheduler {
                 deviceIds
         );
 
-        List<FirmwareDownloadEvents> downloadEvents = questDbRepository.findLatestPerDeviceByCommandIdAndDeviceIds(commandId, deviceIds);
+        List<FirmwareDownloadEvents> downloadEvents = downloadEventsJdbcRepository.findLatestPerDeviceByCommandIdAndDeviceIds(commandId, deviceIds);
         List<FirmwareDownloadEvents> completedEvents = downloadEvents.stream()
                 .filter(e -> isCompleted(e.getStatus()))
                 .toList();

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentRedisService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentRedisService.java
@@ -2,7 +2,7 @@ package com.coffee_is_essential.iot_cloud_ota.service;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.DeployTargetDeviceInfo;
 import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareDownloadEvents;
-import com.coffee_is_essential.iot_cloud_ota.repository.QuestDbRepository;
+import com.coffee_is_essential.iot_cloud_ota.repository.DownloadEventsJdbcRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DeploymentRedisService {
     private final StringRedisTemplate srt;
-    private final QuestDbRepository questDbRepository;
+    private final DownloadEventsJdbcRepository downloadEventsJdbcRepository;
 
     /**
      * 배포 대상 디바이스들을 Redis Set에 추가한다.
@@ -81,7 +81,7 @@ public class DeploymentRedisService {
     @Transactional
     public void saveTimeoutDevices(String commandId, List<Long> deviceIds) {
         for (Long deviceId : deviceIds) {
-            questDbRepository.saveTimeoutDevice(commandId, deviceId);
+            downloadEventsJdbcRepository.saveTimeoutDevice(commandId, deviceId);
         }
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentService.java
@@ -44,7 +44,7 @@ public class DeploymentService {
     private final DeviceJpaRepository deviceJpaRepository;
     private final OverallDeploymentStatusRepository overallDeploymentStatusRepository;
     private final RestClient restClient;
-    private final QuestDbRepository questDbRepository;
+    private final DownloadEventsJdbcRepository downloadEventsJdbcRepository;
     private final CloudFrontSignedUrlService cloudFrontSignedUrlService;
     private final DeploymentRedisService deploymentRedisService;
     private final DeployJudgeScheduler deployJudgeScheduler;
@@ -279,7 +279,7 @@ public class DeploymentService {
         OverallDeploymentStatus status = overallDeploymentStatusRepository.findLatestByDeploymentIdOrElseThrow(id);
         List<Target> targetInfo = getTargetList(deployment);
         ProgressCount progressCount = getProgressCount(id);
-        List<DeviceDeploymentStatus> downloadEvents = questDbRepository.findLatestPerDeviceByCommandId(deployment.getCommandId()).stream()
+        List<DeviceDeploymentStatus> downloadEvents = downloadEventsJdbcRepository.findLatestPerDeviceByCommandId(deployment.getCommandId()).stream()
                 .map(DeviceDeploymentStatus::from)
                 .toList();
 

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -1,10 +1,16 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DeviceResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.entity.*;
 import com.coffee_is_essential.iot_cloud_ota.repository.*;
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -125,4 +131,10 @@ public class DeviceService {
         }
     }
 
+    public List<DeviceResponseDto> findAllDevices(Long regionId, Long groupId, PaginationInfo paginationInfo) {
+        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("createdAt").descending());
+        Page<Device> devicesPage = deviceJpaRepository.findByRegionAndGroup(regionId, groupId, pageable);
+
+        return null;
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -1,8 +1,10 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DeviceListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.PaginationMetadataDto;
 import com.coffee_is_essential.iot_cloud_ota.entity.*;
 import com.coffee_is_essential.iot_cloud_ota.repository.*;
 import jakarta.persistence.EntityManager;
@@ -26,6 +28,7 @@ public class DeviceService {
     private final AdsMetadataJpaRepository adsMetadataJpaRepository;
     private final EntityManager em;
     private final FirmwareDeploymentRepository firmwareDeploymentRepository;
+    private final DeviceStatusJdbcRepository deviceStatusJdbcRepository;
 
     /**
      * 새로운 디바이스를 생성하고 저장합니다.
@@ -131,10 +134,34 @@ public class DeviceService {
         }
     }
 
-    public List<DeviceResponseDto> findAllDevices(Long regionId, Long groupId, PaginationInfo paginationInfo) {
-        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("createdAt").descending());
+    /**
+     * 특정 리전과 그룹에 속한 디바이스 목록을 페이지네이션하여 조회합니다.
+     * 각 디바이스에 대해 최신 시스템 상태의 타임스탬프를 포함한 정보를 DTO 형태로 반환합니다.
+     *
+     * @param regionId       조회할 리전의 ID
+     * @param groupId        조회할 그룹의 ID
+     * @param paginationInfo 페이지네이션 정보 (페이지 번호, 페이지 크기 등)
+     * @return DeviceListResponseDto (디바이스 목록과 페이지 메타데이터)
+     */
+    public DeviceListResponseDto findAllDevices(Long regionId, Long groupId, PaginationInfo paginationInfo) {
+        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("createdAt").ascending());
         Page<Device> devicesPage = deviceJpaRepository.findByRegionAndGroup(regionId, groupId, pageable);
+        List<Device> content = devicesPage.getContent();
 
-        return null;
+        List<DeviceResponseDto> deviceResponseDtos = content.stream()
+                .map(d -> {
+                    SystemStatus status = deviceStatusJdbcRepository.findLatestByDeviceId(d.getDeviceId());
+                    return new DeviceResponseDto(
+                            d.getDeviceId(),
+                            d.getName(),
+                            d.getCreatedAt(),
+                            d.getRegion().getRegionName(),
+                            d.getDivision().getDivisionName(),
+                            status != null ? status.getTimestamp() : null
+                    );
+                })
+                .toList();
+
+        return DeviceListResponseDto.of(deviceResponseDtos, PaginationMetadataDto.from(devicesPage));
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -124,4 +124,5 @@ public class DeviceService {
             em.persist(newFirmware);
         }
     }
+
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DivisionService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DivisionService.java
@@ -1,9 +1,16 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.DivisionListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.entity.Division;
 import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,14 +34,18 @@ public class DivisionService {
     }
 
     /**
-     * 모든 그룹의 기본 정보를 조회합니다.
+     * 전체 그룹의 상세 정보를 페이지네이션하여 조회합니다.
+     * 각 그룹에는 몇 개의 디바이스가 등록되어 있는지를 포함한 정보가 반환됩니다.
      *
-     * @return DivisionResponseDto 리스트 (groupId, groupCode, groupName)
+     * @param paginationInfo 페이지네이션 및 검색어 정보
+     * @return 페이징된 그룹 상세 정보 목록과 페이지 정보가 포함된 응답 DTO
      */
-    public List<DivisionResponseDto> findAllDivisions() {
+    public DivisionListResponseDto findAllDivisions(PaginationInfo paginationInfo) {
+        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("id").ascending());
+        String keyword = paginationInfo.search();
 
-        return divisionJpaRepository.findAll().stream()
-                .map(DivisionResponseDto::from)
-                .toList();
+        Page<Division> divisionPage = divisionJpaRepository.searchWithNullableKeyword(keyword, pageable);
+
+        return DivisionListResponseDto.from(divisionPage);
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DivisionService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DivisionService.java
@@ -1,5 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
+import com.coffee_is_essential.iot_cloud_ota.dto.DivisionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.DivisionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.repository.DivisionJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,18 @@ public class DivisionService {
         return divisionJpaRepository.findDivisionSummary()
                 .stream()
                 .map(DivisionSummaryResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 모든 그룹의 기본 정보를 조회합니다.
+     *
+     * @return DivisionResponseDto 리스트 (groupId, groupCode, groupName)
+     */
+    public List<DivisionResponseDto> findAllDivisions() {
+
+        return divisionJpaRepository.findAll().stream()
+                .map(DivisionResponseDto::from)
                 .toList();
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
@@ -1,5 +1,6 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,20 @@ public class RegionService {
      */
     public List<RegionSummaryResponseDto> findRegionSummary() {
 
-        return regionJpaRepository.findRegionSummary()
-                .stream()
+        return regionJpaRepository.findRegionSummary().stream()
                 .map(RegionSummaryResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 모든 리전의 상세 정보를 조회합니다.
+     *
+     * @return RegionResponseDto 리스트 (regionId, regionCode, regionName 포함)
+     */
+    public List<RegionResponseDto> findAllRegions() {
+
+        return regionJpaRepository.findAll().stream()
+                .map(RegionResponseDto::from)
                 .toList();
     }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/RegionService.java
@@ -1,9 +1,16 @@
 package com.coffee_is_essential.iot_cloud_ota.service;
 
+import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
+import com.coffee_is_essential.iot_cloud_ota.dto.RegionListResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionResponseDto;
 import com.coffee_is_essential.iot_cloud_ota.dto.RegionSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.entity.Region;
 import com.coffee_is_essential.iot_cloud_ota.repository.RegionJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -26,14 +33,18 @@ public class RegionService {
     }
 
     /**
-     * 모든 리전의 상세 정보를 조회합니다.
+     * 전체 리전의 상세 정보를 페이지네이션하여 조회합니다.
+     * 각 리전에는 몇 개의 디바이스가 등록되어 있는지를 포함한 정보가 반환됩니다.
      *
-     * @return RegionResponseDto 리스트 (regionId, regionCode, regionName 포함)
+     * @param paginationInfo 페이지네이션 및 검색어 정보
+     * @return 페이징된 리전 상세 정보 목록과 페이지 정보가 포함된 응답 DTO
      */
-    public List<RegionResponseDto> findAllRegions() {
+    public RegionListResponseDto findAllRegions(PaginationInfo paginationInfo) {
+        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("id").ascending());
+        String keyword = paginationInfo.search();
 
-        return regionJpaRepository.findAll().stream()
-                .map(RegionResponseDto::from)
-                .toList();
+        Page<Region> regionPage = regionJpaRepository.searchWithNullableKeyword(keyword, pageable);
+
+        return RegionListResponseDto.from(regionPage);
     }
 }


### PR DESCRIPTION
# Changelog

- 그룹 리스트 조회 API 개발 `GET /api/groups/list`
- 리전 리스트 조회 API 개발 `GET /api/regions/list`
- 기기 리스트 조회 API 개발 `GET /api/devices/list`
- 기기 상세 정보 조회 API 개발 `GET /api/devices/{id}`

# Testing

- 각 API에 대해 Postman/Swagger를 활용한 수동 테스트 진행
- 그룹 리스트 조회 API
<img width="394" height="651" alt="image" src="https://github.com/user-attachments/assets/1c42906a-90dc-4015-8815-d5714f452bf1" />

- 리전 리스트 조회 API
<img width="377" height="553" alt="image" src="https://github.com/user-attachments/assets/6c8d1b49-9c0b-46ac-8884-fe244a6b5717" />

- 기기 리스트 조회 API
<img width="514" height="557" alt="image" src="https://github.com/user-attachments/assets/42ca6f2f-a935-49ac-80ba-a4a3920c232c" />

- 기기 상세 정보 API
<img width="437" height="696" alt="image" src="https://github.com/user-attachments/assets/d54ae6d1-3916-4a4b-82a4-6183dc53a355" />

# Ops Impact

N/A

# Version Compatibility

N/A