### PR TITLE
[Backend/Mqtt Handler] QuestDB 스키마 및 Golang/Java 코드에서 download_seconds → download_ms로 변경

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DownloadEventsJdbcRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/DownloadEventsJdbcRepository.java
@@ -85,7 +85,7 @@ public class DownloadEventsJdbcRepository {
             e.setDownloadBytes(rs.getLong("download_bytes"));
             e.setSpeedKbps(rs.getDouble("speed_kbps"));
             e.setChecksumVerified(rs.getBoolean("checksum_verified"));
-            e.setDownloadTime(rs.getLong("download_seconds"));
+            e.setDownloadTime(rs.getLong("download_ms"));
             e.setTimestamp(rs.getTimestamp("timestamp"));
 
             return e;

--- a/mqtt-handler/mqttclient/download_subscriber.go
+++ b/mqtt-handler/mqttclient/download_subscriber.go
@@ -68,7 +68,7 @@ func parseDownloadResult(msg mqtt.Message) (*types.DownloadEvent, error) {
 	}
 
 	return buildDownloadEvent(msg.Topic(), result.CommandID, result.Message, result.Status,
-		0, 0, 0, 0, result.ChecksumVerified, result.DownloadSeconds, result.Timestamp), nil
+		0, 0, 0, 0, result.ChecksumVerified, result.DownloadMs, result.Timestamp), nil
 }
 
 // 다운로드 취소 응답 메시지 처리
@@ -98,7 +98,7 @@ func buildDownloadEvent(topic, commandID, message, status string, progress int64
 		DownloadBytes:    downloadBytes,
 		SpeedKbps:        speedKbps,
 		ChecksumVerified: verified,
-		DownloadSeconds:  downloadTime,
+		DownloadMs:       downloadTime,
 		Timestamp:        timestamp,
 	}
 }

--- a/mqtt-handler/mqttclient/publisher.go
+++ b/mqtt-handler/mqttclient/publisher.go
@@ -48,7 +48,7 @@ func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 				DownloadBytes:    0,
 				SpeedKbps:        0,
 				ChecksumVerified: false,
-				DownloadSeconds:  0,
+				DownloadMs:       0,
 			}
 
 			repository.DownloadInsertChan <- event
@@ -99,7 +99,7 @@ func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest
 				DownloadBytes:    0,
 				SpeedKbps:        0,
 				ChecksumVerified: false,
-				DownloadSeconds:  0,
+				DownloadMs:       0,
 			}
 
 			repository.DownloadInsertChan <- event
@@ -157,7 +157,7 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 				DownloadBytes:    0,
 				SpeedKbps:        0,
 				ChecksumVerified: false,
-				DownloadSeconds:  0,
+				DownloadMs:       0,
 			}
 
 			repository.DownloadInsertChan <- event

--- a/mqtt-handler/repository/event_consumer.go
+++ b/mqtt-handler/repository/event_consumer.go
@@ -19,7 +19,7 @@ func (c *DBClient) StartEventConsumer() {
 			Int64Column("download_bytes", event.DownloadBytes).
 			Float64Column("speed_kbps", event.SpeedKbps).
 			BoolColumn("checksum_verified", event.ChecksumVerified).
-			Int64Column("download_seconds", event.DownloadSeconds).
+			Int64Column("download_ms", event.DownloadMs).
 			At(ctx, event.Timestamp.UTC())
 
 		if err != nil {

--- a/mqtt-handler/types/event.go
+++ b/mqtt-handler/types/event.go
@@ -12,7 +12,7 @@ type DownloadEvent struct {
 	DownloadBytes    int64
 	SpeedKbps        float64
 	ChecksumVerified bool
-	DownloadSeconds  int64
+	DownloadMs       int64
 	Timestamp        time.Time
 }
 
@@ -27,7 +27,7 @@ type DownloadResult struct {
 	Status           string    `json:"status"`
 	Message          string    `json:"message"`
 	ChecksumVerified bool      `json:"checksum_verified"`
-	DownloadSeconds  int64     `json:"download_seconds"`
+	DownloadMs       int64     `json:"download_ms"`
 	Timestamp        time.Time `json:"timestamp"`
 }
 


### PR DESCRIPTION
# Changelog

- QuestDB `download_events` 테이블 컬럼명 `download_seconds` → `download_ms` 변경
- Golang 코드에서 변수 및 매핑 수정 (`download_seconds` → `download_ms`)
- Java JdbcTemplate 매핑 코드 수정 (`rs.getLong("download_ms")`)

# Testing

- 로컬 QuestDB에서 컬럼 변경 후 데이터 정상 조회 확인
<img width="992" height="125" alt="image" src="https://github.com/user-attachments/assets/10972cd8-f9cf-4a57-959f-df4ba4e9eb7d" />

# Ops Impact

N/A

# Version Compatibility

N/A