### PR TITLE
[Mqtt Handler] 매출/거래 데이터 관련 Mqtt Topic 구독 및 QuestDB sales_data 테이블 추가

### DIFF
--- a/mqtt-handler/mqttclient/client.go
+++ b/mqtt-handler/mqttclient/client.go
@@ -91,5 +91,5 @@ func (m *MQTTClient) SubscribeAllTopics() {
 	m.subscribe("v1/+/update/cancel/ack", parseDownloadCancelAck, "[CANCEL ACK]")
 	m.subscribeSystemStatus("v1/+/status/system", parseSystemStatus, "[SYSTEM STATUS]")
 	m.subscribeErrorLog("v1/+/status/error_log", parseErrorLog, "[ERROR LOG]")
-	m.subscribeSalesData("v1/+/sales/data", parseSalesItem, "[SALES ITEM]")
+	m.subscribeSalesData("v1/+/sales/data", parseSalesItem, "[SALES DATA]")
 }

--- a/mqtt-handler/mqttclient/client.go
+++ b/mqtt-handler/mqttclient/client.go
@@ -91,4 +91,5 @@ func (m *MQTTClient) SubscribeAllTopics() {
 	m.subscribe("v1/+/update/cancel/ack", parseDownloadCancelAck, "[CANCEL ACK]")
 	m.subscribeSystemStatus("v1/+/status/system", parseSystemStatus, "[SYSTEM STATUS]")
 	m.subscribeErrorLog("v1/+/status/error_log", parseErrorLog, "[ERROR LOG]")
+	m.subscribeSalesData("v1/+/sales/data", parseSalesItem, "[SALES ITEM]")
 }

--- a/mqtt-handler/mqttclient/sales_subscriber.go
+++ b/mqtt-handler/mqttclient/sales_subscriber.go
@@ -1,0 +1,56 @@
+package mqttclient
+
+import (
+	"encoding/json"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"log"
+	"mqtt-handler/repository"
+	"mqtt-handler/types"
+	"strconv"
+	"strings"
+)
+
+// 에러 로그 메시지 구독 및 처리
+func (m *MQTTClient) subscribeSalesData(topic string, parseFunc func(mqtt.Message) (*types.SalesDataEvent, error), label string) {
+	handler := func(client mqtt.Client, msg mqtt.Message) {
+		log.Printf("[MQTT] %s 수신 - 토픽: %s", label, msg.Topic())
+
+		event, err := parseFunc(msg)
+		if err != nil {
+			log.Printf("[ERROR] %s 메시지 파싱 실패: %v", label, err)
+			return
+		}
+
+		repository.SalesDataInsertChan <- *event
+	}
+
+	token := m.mqttClient.Subscribe(topic, 1, handler)
+	token.Wait()
+	if token.Error() != nil {
+		log.Printf("[ERROR] %s 구독 실패: %v", label, token.Error())
+	} else {
+		log.Printf("[MQTT] 구독 성공: %s", topic)
+	}
+}
+
+// 에러 로그 메시지 파싱
+func parseSalesItem(msg mqtt.Message) (*types.SalesDataEvent, error) {
+	var salesData types.SalesData
+	if err := json.Unmarshal(msg.Payload(), &salesData); err != nil {
+
+		return nil, err
+	}
+
+	return buildSalesItem(msg.Topic(), salesData), nil
+}
+
+// 이벤트 빌더 - 토픽에서 ID 추출 + 이벤트 생성
+func buildSalesItem(topic string, salesData types.SalesData) *types.SalesDataEvent {
+	topicParts := strings.Split(topic, "/")
+	deviceId, _ := strconv.ParseInt(topicParts[1], 10, 64)
+
+	return &types.SalesDataEvent{
+		DeviceId:  deviceId,
+		SalesData: salesData,
+	}
+}

--- a/mqtt-handler/repository/questdb_repository.go
+++ b/mqtt-handler/repository/questdb_repository.go
@@ -24,6 +24,9 @@ var SystemStatusInsertChan = make(chan types.SystemStatusEvent, 1000)
 // 에러 로그 이벤트 처리를 위한 비동기 채널
 var ErrorLogInsertChan = make(chan types.ErrorLogEvent, 1000)
 
+// 판매 데이터 이벤트 처리를 위한 비동기 채널
+var SalesDataInsertChan = make(chan types.SalesDataEvent, 1000)
+
 // DBClient는 QuestDB와 통신하기 위한 객체입니다.
 type DBClient struct {
 	sender questdb.LineSender

--- a/mqtt-handler/types/sales.go
+++ b/mqtt-handler/types/sales.go
@@ -1,0 +1,14 @@
+package types
+
+import "time"
+
+type SalesData struct {
+	Type      string    `json:"type"`
+	SubType   string    `json:"sub_type"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type SalesDataEvent struct {
+	DeviceId  int64
+	SalesData SalesData
+}


### PR DESCRIPTION
# Changelog

- MQTT 토픽 `v1/{기기ID}/sales/data` 구독 로직 추가
- QuestDB `sales_data` 테이블 생성 및 저장 로직 구현

# Testing

- 로컬 환경에서 기기 → 클라우드로 sales 이벤트 publish 후 DB 저장 확인
- `type`, `sub_type`, `timestamp` 필드 정상 반영 확인
<img width="1310" height="220" alt="image" src="https://github.com/user-attachments/assets/790aa997-62f1-4382-9295-5aafdb4e1fbc" />

# Ops Impact

N/A

# Version Compatibility

N/A