### PR TITLE
[Frontend] 변경된 그룹 API와 동기화

### DIFF
--- a/frontend/src/entities/group/api/api.ts
+++ b/frontend/src/entities/group/api/api.ts
@@ -14,7 +14,7 @@ export const GroupApiService = {
    * const groups = await GroupApiService.getGroups();
    */
   getGroups: async (): Promise<Group[]> => {
-    const { data } = await apiClient.get<Group[]>(`/api/divisions`);
+    const { data } = await apiClient.get<Group[]>(`/api/groups`);
     return data;
   },
 };


### PR DESCRIPTION
# Changelog
- 배포 모달 창에서 그룹 리스트를 조회할 때 사용되는 API가 변경되었습니다. `/api/divisions` -> `/api/groups`. 이에 따라 API 호출 URL을 동기화하였습니다.

# Testing
<img width="884" height="752" alt="image" src="https://github.com/user-attachments/assets/dd4bec39-b9e8-4f6e-881e-48979911df26" />

# Ops Impact
N/A

# Version Compatibility
N/A