### PR TITLE
[Frontend] 기기 상세 정보 페이지 구현

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -9,6 +9,7 @@ import { DevicePage } from "../pages/DevicePage";
 import { FirmwareDeploymentPage } from "../pages/FirmwareDeploymentPage";
 import { FirmwareDeploymentDetailPage } from "../pages/FirmwareDeploymentDetailPage";
 import { AdDetailPage } from "../pages/AdDetailPage";
+import { DeviceDetailPage } from "../pages/DeviceDetailPage";
 
 export const Router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ export const Router = createBrowserRouter([
         element: <FirmwareDeploymentDetailPage />,
       },
       { path: "device", element: <DevicePage /> },
+      { path: "device/:deviceId", element: <DeviceDetailPage /> },
       { path: "ads", element: <AdListPage /> },
       { path: "ads/:id", element: <AdDetailPage /> },
       { path: "monitoring", element: <MonitoringPage /> },

--- a/frontend/src/entities/device/api/api.ts
+++ b/frontend/src/entities/device/api/api.ts
@@ -1,6 +1,11 @@
 import { apiClient } from "../../../shared/api/client";
 import { PaginatedApiResponse } from "../../../shared/api/types";
-import { Device, PaginatedDevice } from "../model/types";
+import {
+  Device,
+  DeviceDetail,
+  DeviceDetailResponse,
+  PaginatedDevice,
+} from "../model/types";
 
 /**
  * API로부터 디바이스(Device) 데이터를 가져오는 서비스입니다.
@@ -60,6 +65,31 @@ export const deviceApiService = {
         lastActiveAt: new Date(device.lastActiveAt!),
       })),
       paginationMeta: data.paginationMeta,
+    };
+  },
+
+  /**
+   * 특정 디바이스(Device)의 상세 정보를 조회합니다.
+   * @async
+   * @param {number} deviceId - 조회할 디바이스의 ID
+   * @returns {Promise<DeviceDetail>} 디바이스 상세 정보 객체를 반환합니다.
+   * @example
+   * const deviceDetail = await deviceApiService.getDeviceDetail(1);
+   */
+  getDeviceDetail: async (deviceId: number): Promise<DeviceDetail> => {
+    const { data } = await apiClient.get<DeviceDetailResponse>(
+      `/api/devices/${deviceId}`,
+    );
+
+    return {
+      ...data,
+      createdAt: new Date(data.createdAt),
+      modifiedAt: new Date(data.modifiedAt),
+      lastActiveAt: data.lastActiveAt ? new Date(data.lastActiveAt) : null,
+      advertisements: data.advertisements.map((ad) => ({
+        ...ad,
+        deployedAt: new Date(ad.deployedAt),
+      })),
     };
   },
 };

--- a/frontend/src/entities/device/api/useDeviceDetail.tsx
+++ b/frontend/src/entities/device/api/useDeviceDetail.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { deviceApiService } from "./api";
+
+/**
+ * useDeviceDetail 훅은 주어진 디바이스 ID에 해당하는 디바이스의 상세 정보를
+ * API를 통해 가져오는 React Query 훅입니다.
+ * @param deviceId - 상세 정보를 가져올 디바이스의 ID
+ * @returns React Query의 쿼리 결과 객체
+ */
+export const useDeviceDetail = (deviceId: number) => {
+  return useQuery({
+    queryKey: ["device", deviceId],
+    queryFn: () => deviceApiService.getDeviceDetail(deviceId),
+  });
+};
+

--- a/frontend/src/entities/device/model/types.ts
+++ b/frontend/src/entities/device/model/types.ts
@@ -19,3 +19,65 @@ export interface PaginatedDevice {
   items: Device[];
   paginationMeta: PaginationMeta;
 }
+
+/**
+ * 기기 상세 정보 응답 타입을 정의하는 인터페이스입니다.
+ */
+export interface DeviceDetailResponse {
+  deviceId: number;
+  deviceName: string;
+  createdAt: string;
+  modifiedAt: string;
+  lastActiveAt: string | null;
+  region: {
+    id: number;
+    code: string;
+    name: string;
+  };
+  group: {
+    id: number;
+    code: string;
+    name: string;
+  };
+  firmware: {
+    id: number;
+    version: string;
+  };
+  advertisements: {
+    id: number;
+    title: string;
+    deployedAt: string;
+    originalSignedUrl: string;
+  }[];
+}
+
+/**
+ * 기기 상세 정보를 나타내는 인터페이스입니다.
+ */
+export interface DeviceDetail {
+  deviceId: number;
+  deviceName: string;
+  createdAt: Date;
+  modifiedAt: Date;
+  lastActiveAt: Date | null;
+  region: {
+    id: number;
+    code: string;
+    name: string;
+  };
+  group: {
+    id: number;
+    code: string;
+    name: string;
+  };
+  firmware: {
+    id: number;
+    version: string;
+  };
+  advertisements: {
+    id: number;
+    title: string;
+    deployedAt: Date;
+    originalSignedUrl: string;
+  }[];
+}

--- a/frontend/src/entities/device/ui/DeviceCard.tsx
+++ b/frontend/src/entities/device/ui/DeviceCard.tsx
@@ -1,4 +1,5 @@
 import { JSX } from "react";
+import { useNavigate } from "react-router";
 import { Device } from "../model/types";
 
 /**
@@ -14,12 +15,20 @@ export interface DeviceCardProps {
  * @returns {JSX.Element} 디바이스 정보를 포함하는 JSX 요소
  */
 export const DeviceCard = ({ device }: DeviceCardProps): JSX.Element => {
+  const navigate = useNavigate();
   const lastActive = device.lastActiveAt
     ? new Date(device.lastActiveAt).toLocaleString()
     : "N/A";
 
+  const handleCardClick = () => {
+    navigate(`/device/${device.deviceId}`);
+  };
+
   return (
-    <div className="bg-white border rounded-lg p-4 shadow-sm hover:shadow-lg transition-shadow duration-300 flex items-center space-x-4">
+    <div
+      className="bg-white border rounded-lg p-4 shadow-sm hover:shadow-lg transition-shadow duration-300 flex items-center space-x-4 cursor-pointer"
+      onClick={handleCardClick}
+    >
       <div className="flex-shrink-0">
         <img className="h-24 w-24" src="/robot.png" alt="robot" />
       </div>

--- a/frontend/src/entities/device/ui/DeviceDetailView.tsx
+++ b/frontend/src/entities/device/ui/DeviceDetailView.tsx
@@ -1,0 +1,155 @@
+import { useParams } from "react-router";
+import { useDeviceDetail } from "../api/useDeviceDetail";
+import { MainTile } from "../../../widgets/layout/ui/MainTile";
+import { TitleTile } from "../../../widgets/layout/ui/TitleTile";
+
+/**
+ * DeviceDetailView 컴포넌트는 특정 디바이스의 상세 정보를 보여줍니다.
+ * 디바이스의 ID를 URL 파라미터에서 가져와 API를 통해 데이터를 로드하고,
+ * 디바이스의 상태, 지역, 그룹, 펌웨어 버전, 생성일 및 수정일 등의 정보를 표시합니다.
+ * 또한, 디바이스가 표시하고 있는 광고의 썸네일과 제목도 함께 보여줍니다.
+ * 디바이스가 마지막으로 활성화된 시간이 5분 이내인 경우 "활성" 상태로 표시하며,
+ * 그렇지 않은 경우 "비활성" 상태로 표시합니다.
+ */
+export const DeviceDetailView = () => {
+  const { deviceId } = useParams<{ deviceId: string }>();
+  const parsedId = deviceId ? parseInt(deviceId) : null;
+
+  if (parsedId === null || isNaN(parsedId)) {
+    return <div>유효하지 않은 디바이스 ID입니다.</div>;
+  }
+
+  const { data: device, isLoading, error } = useDeviceDetail(parsedId);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  if (!device) {
+    return <div>Device not found</div>;
+  }
+
+  const isActive =
+    device.lastActiveAt &&
+    new Date().getTime() - new Date(device.lastActiveAt).getTime() <
+      5 * 60 * 1000; // 5 minutes
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="col-span-2">
+        <TitleTile
+          title={`디바이스 상세 정보`}
+          description={`디바이스의 상세 정보 및 광고 내역`}
+        />
+      </div>
+      <MainTile title="디바이스 정보">
+        <div>
+          <div className="flex gap-8">
+            <dl className="divide-y divide-gray-200 w-1/2">
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">
+                  디바이스 이름
+                </dt>
+                <dd className="mt-1 text-lg font-semibold text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.deviceName}
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">
+                  디바이스 ID
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.deviceId}
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">상태</dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  <div className="flex items-center">
+                    <span
+                      className={`h-2.5 w-2.5 rounded-full ${
+                        isActive ? "bg-green-500" : "bg-gray-400"
+                      } mr-2`}
+                    ></span>
+                    <span>{isActive ? "활성" : "비활성"}</span>
+                    <span className="ml-4 text-xs text-gray-500">
+                      (마지막 활성:{" "}
+                      {device.lastActiveAt
+                        ? device.lastActiveAt.toLocaleString()
+                        : "N/A"}
+                      )
+                    </span>
+                  </div>
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">
+                  지역 / 그룹
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.region.name} / {device.group.name}
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">
+                  펌웨어 버전
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.firmware?.version ?? "알 수 없음"}
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">생성일</dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.createdAt.toLocaleString()}
+                </dd>
+              </div>
+              <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                <dt className="text-sm font-medium text-gray-500">수정일</dt>
+                <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                  {device.modifiedAt.toLocaleString()}
+                </dd>
+              </div>
+            </dl>
+            <div className="border border-gray-200 rounded-md text-center p-4 flex-1">
+              메트릭 차트 자리
+            </div>
+          </div>
+        </div>
+      </MainTile>
+
+      <MainTile title="표시되고 있는 광고">
+        <div className="flex justify-between space-x-8">
+          {Array.from({ length: 3 }).map((_, index) => {
+            const ad = device.advertisements[index];
+            return (
+              <div
+                key={ad ? `ad-${ad.id}` : `placeholder-${index}`}
+                className="w-full"
+              >
+                <div className="w-full aspect-[4/3] rounded-md shadow-md">
+                  {ad ? (
+                    <img
+                      src={ad.originalSignedUrl}
+                      alt={ad.title}
+                      className="w-full h-full object-cover rounded-md"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-white border-2 border-dashed border-gray-300 rounded-md" />
+                  )}
+                </div>
+                <div className="text-sm mt-2 text-center text-gray-600 truncate">
+                  {ad ? ad.title : "비어있음"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </MainTile>
+    </div>
+  );
+};

--- a/frontend/src/pages/DeviceDetailPage.tsx
+++ b/frontend/src/pages/DeviceDetailPage.tsx
@@ -1,0 +1,9 @@
+import { DeviceDetailView } from "../entities/device/ui/DeviceDetailView";
+
+/**
+ * DeviceDetailPage 컴포넌트는 특정 디바이스의 상세 정보를 보여주는 페이지입니다.
+ * URL 파라미터에서 디바이스 ID를 가져와 DeviceDetailView 컴포넌트를 렌더링합니다.
+ */
+export const DeviceDetailPage = () => {
+  return <DeviceDetailView />;
+};


### PR DESCRIPTION
# Changelog
- 기기 상세 정보를 보여주는 페이지를 구현하였습니다.
  - 두 개의 MainTile로 나누고, 첫번째에는 기기 관련 정보와 메트릭 그래프 표시, 두번째에는 표시중인 광고를 보여주도록 구성하였습니다.
- 기기 상세 정보 API를 요청하는 `getDeviceDetail()` 을 구현하였습니다.

# Testing
<img width="2539" height="1348" alt="image" src="https://github.com/user-attachments/assets/169e6c4e-0917-4131-a1a2-79928a8b64df" />

# Ops Impact
N/A

# Version Compatibility
N/A