### PR TITLE
[Backend] 기기 활성화 상태를 최근 5분 이내 여부로 판별하도록 로직 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceDetailResponseDto.java
@@ -9,6 +9,7 @@ public record DeviceDetailResponseDto(
         OffsetDateTime createdAt,
         OffsetDateTime modifiedAt,
         OffsetDateTime lastActiveAt,
+        boolean isActive,
         DeviceDetailRegionDto region,
         DeviceDetailDivisionDto group,
         FirmwareResponseDto firmware,

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceSummaryResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceSummaryResponseDto.java
@@ -1,7 +1,5 @@
 package com.coffee_is_essential.iot_cloud_ota.dto;
 
-import com.coffee_is_essential.iot_cloud_ota.domain.DeviceSummary;
-
 /**
  * 디바이스 요약 정보를 담는 응답 DTO 입니다.
  *
@@ -18,13 +16,4 @@ public record DeviceSummaryResponseDto(
         String groupName,
         boolean isActive
 ) {
-    public static DeviceSummaryResponseDto from(DeviceSummary deviceSummary) {
-        return new DeviceSummaryResponseDto(
-                deviceSummary.getDeviceId(),
-                deviceSummary.getDeviceName(),
-                deviceSummary.getRegionName(),
-                deviceSummary.getGroupName(),
-                true
-        );
-    }
 }


### PR DESCRIPTION
# Changelog

- `/api/devices/{id}`, `/api/devices` 응답 DTO에 isActive 필드 추가
- 최근 5분 이내 상태 여부를 기준으로 활성화 여부 반환

# Testing
- 로컬에서 API 호출 시 `isActive` 값 정상 반환 확인
- `/api/devices`
<img width="466" height="522" alt="image" src="https://github.com/user-attachments/assets/484250e3-d956-49fb-a1c6-762835b8fac1" />

- `/api/devices/{id}
<img width="499" height="391" alt="image" src="https://github.com/user-attachments/assets/754de4dc-ad36-4a42-898b-d4cf95dd1314" />

# Ops Impact

N/A

# Version Compatibility

N/A
