### PR TITLE
[Mqtt Handler] QuestDB 테이블 스키마 수정 반영

### DIFF
--- a/mqtt-handler/mqttclient/status_subscriber.go
+++ b/mqtt-handler/mqttclient/status_subscriber.go
@@ -50,11 +50,11 @@ func buildSystemStatusEvent(topic string, status types.SystemStatus) *types.Syst
 	deviceId, _ := strconv.ParseInt(topicParts[1], 10, 64)
 
 	return &types.SystemStatusEvent{
-		DeviceId:       deviceId,
-		FirmwareId:     status.FirmwareId,
-		Advertisements: status.Advertisements,
-		System:         status.System,
-		Network:        status.Network,
-		Timestamp:      status.Timestamp,
+		DeviceId:        deviceId,
+		FirmwareVersion: status.FirmwareVersion,
+		Advertisements:  status.Advertisements,
+		System:          status.System,
+		Network:         status.Network,
+		Timestamp:       status.Timestamp,
 	}
 }

--- a/mqtt-handler/repository/event_consumer.go
+++ b/mqtt-handler/repository/event_consumer.go
@@ -76,7 +76,7 @@ func (c *DBClient) StartSystemStatusConsumer() {
 		// 4. firmware_status 저장
 		if err := c.sender.Table("firmware_status").
 			Int64Column("device_id", event.DeviceId).
-			Int64Column("firmware_id", event.FirmwareId).
+			StringColumn("firmware_version", event.FirmwareVersion).
 			At(ctx, event.Timestamp.UTC()); err != nil {
 			log.Printf("[ERROR] firmware_status Insert 실패: %v", err)
 		}

--- a/mqtt-handler/types/status.go
+++ b/mqtt-handler/types/status.go
@@ -3,11 +3,11 @@ package types
 import "time"
 
 type SystemStatus struct {
-	FirmwareId     int64            `json:"firmware_id"`
-	Advertisements []Advertisements `json:"advertisements"`
-	System         System           `json:"system"`
-	Network        Network          `json:"network"`
-	Timestamp      time.Time        `json:"timestamp"`
+	FirmwareVersion string           `json:"firmware_version"`
+	Advertisements  []Advertisements `json:"advertisements"`
+	System          System           `json:"system"`
+	Network         Network          `json:"network"`
+	Timestamp       time.Time        `json:"timestamp"`
 }
 
 type Advertisements struct {
@@ -34,12 +34,12 @@ type Network struct {
 }
 
 type SystemStatusEvent struct {
-	DeviceId       int64
-	FirmwareId     int64
-	Advertisements []Advertisements
-	System         System
-	Network        Network
-	Timestamp      time.Time
+	DeviceId        int64
+	FirmwareVersion string
+	Advertisements  []Advertisements
+	System          System
+	Network         Network
+	Timestamp       time.Time
 }
 
 type ErrorLog struct {


### PR DESCRIPTION
# Changelog

- `firmware_status`의 컬럼 `firmware_id(Int64)` 제거, `firmware_version(String)`으로 변경
- QuestDB 테이블 스키마 수정 반영

# Testing

- 로컬 환경에서 이벤트 insert 시 `firmware_version` 정상 저장 확인
<img width="629" height="104" alt="image" src="https://github.com/user-attachments/assets/6500c7c7-81ea-4a0d-84fe-5d5541afedf1" />

# Ops Impact

- DB 스키마 변경 사항 있음 (기존 `firmware_id` 컬럼 제거, `firmware_version` 추가)

# Version Compatibility

N/A