### PR TITLE
[Frontend] 그룹 / 리전 생성 기능 구현

### DIFF
--- a/frontend/src/entities/firmware/api/api.ts
+++ b/frontend/src/entities/firmware/api/api.ts
@@ -144,7 +144,7 @@ export const firmwareApiService = {
     fileName: string,
   ): Promise<string> => {
     const { data } = await apiClient.get<PresignedDownloadUrlResponse>(
-      `/api/s3/presigned_download`,
+      `/api/s3/firmware/download`,
       {
         params: {
           version,

--- a/frontend/src/entities/group/api/api.ts
+++ b/frontend/src/entities/group/api/api.ts
@@ -17,4 +17,17 @@ export const GroupApiService = {
     const { data } = await apiClient.get<Group[]>(`/api/groups`);
     return data;
   },
+
+  /**
+   * 새로운 그룹(Group)을 등록합니다.
+   * @async
+   * @param {string} groupName - 등록할 그룹의 이름
+   * @returns {Promise<Group>} 등록된 그룹 정보 객체를 반환합니다.
+   * @example
+   * const newGroup = await GroupApiService.registerGroup('New Group');
+   */
+  registerGroup: async (groupName: string): Promise<Group> => {
+    const { data } = await apiClient.post<Group>(`/api/groups`, { groupName });
+    return data;
+  },
 };

--- a/frontend/src/entities/region/api/regionApi.ts
+++ b/frontend/src/entities/region/api/regionApi.ts
@@ -17,4 +17,19 @@ export const RegionApiService = {
     const { data } = await apiClient.get<Region[]>(`/api/regions`);
     return data;
   },
+
+  /**
+   * 새로운 지역(Region)을 등록합니다.
+   * @async
+   * @param {string} regionName - 등록할 지역의 이름
+   * @returns {Promise<Region>} 등록된 지역 정보 객체를 반환합니다.
+   * @example
+   * const newRegion = await RegionApiService.registerRegion('New Region');
+   */
+  registerRegion: async (regionName: string): Promise<Region> => {
+    const { data } = await apiClient.post<Region>(`/api/regions`, {
+      regionName,
+    });
+    return data;
+  },
 };

--- a/frontend/src/features/device_filter/ui/DeviceFilter.tsx
+++ b/frontend/src/features/device_filter/ui/DeviceFilter.tsx
@@ -3,7 +3,8 @@ import { Group } from "../../../entities/group/model/types";
 import { Region } from "../../../entities/region/model/types";
 import { GroupApiService } from "../../../entities/group/api/api";
 import { RegionApiService } from "../../../entities/region/api/regionApi";
-import { Filter, X } from "lucide-react";
+import { Filter, X, Plus } from "lucide-react";
+import { toast } from "react-toastify";
 
 /**
  * DeviceFilter 컴포넌트 Props
@@ -30,6 +31,11 @@ export const DeviceFilter = ({
   const regionRef = useRef<HTMLDivElement>(null);
   const groupRef = useRef<HTMLDivElement>(null);
 
+  const [isAddingRegion, setIsAddingRegion] = useState(false);
+  const [newRegionName, setNewRegionName] = useState("");
+  const [isAddingGroup, setIsAddingGroup] = useState(false);
+  const [newGroupName, setNewGroupName] = useState("");
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -53,12 +59,16 @@ export const DeviceFilter = ({
         !regionRef.current.contains(event.target as Node)
       ) {
         setShowRegionFilter(false);
+        setIsAddingRegion(false);
+        setNewRegionName("");
       }
       if (
         groupRef.current &&
         !groupRef.current.contains(event.target as Node)
       ) {
         setShowGroupFilter(false);
+        setIsAddingGroup(false);
+        setNewGroupName("");
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
@@ -77,6 +87,34 @@ export const DeviceFilter = ({
     setSelectedGroupId(groupId);
     onFilterChange({ regionId: selectedRegionId, groupId: groupId });
     setShowGroupFilter(false);
+  };
+
+  const handleRegisterRegion = async () => {
+    if (newRegionName.trim() === "") return;
+    try {
+      const newRegion = await RegionApiService.registerRegion(
+        newRegionName.trim(),
+      );
+      setRegions((prev) => [...prev, newRegion]);
+      setNewRegionName("");
+      setIsAddingRegion(false);
+    } catch (error) {
+      console.error(error);
+      toast.error("리전 등록에 실패했습니다.");
+    }
+  };
+
+  const handleRegisterGroup = async () => {
+    if (newGroupName.trim() === "") return;
+    try {
+      const newGroup = await GroupApiService.registerGroup(newGroupName.trim());
+      setGroups((prev) => [...prev, newGroup]);
+      setNewGroupName("");
+      setIsAddingGroup(false);
+    } catch (error) {
+      console.error(error);
+      toast.error("그룹 등록에 실패했습니다.");
+    }
   };
 
   const selectedRegionName = regions.find(
@@ -126,6 +164,33 @@ export const DeviceFilter = ({
                   {region.regionName}
                 </li>
               ))}
+              {isAddingRegion ? (
+                <li className="p-2">
+                  <input
+                    type="text"
+                    value={newRegionName}
+                    onChange={(e) => setNewRegionName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRegisterRegion();
+                      if (e.key === "Escape") {
+                        setIsAddingRegion(false);
+                        setNewRegionName("");
+                      }
+                    }}
+                    className="w-full border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="새 리전 이름"
+                    autoFocus
+                  />
+                </li>
+              ) : (
+                <li
+                  className="flex items-center px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm text-blue-600"
+                  onClick={() => setIsAddingRegion(true)}
+                >
+                  <Plus size={14} className="mr-2" />
+                  새로 만들기
+                </li>
+              )}
             </ul>
           </div>
         )}
@@ -169,6 +234,33 @@ export const DeviceFilter = ({
                   {group.groupName}
                 </li>
               ))}
+              {isAddingGroup ? (
+                <li className="p-2">
+                  <input
+                    type="text"
+                    value={newGroupName}
+                    onChange={(e) => setNewGroupName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRegisterGroup();
+                      if (e.key === "Escape") {
+                        setIsAddingGroup(false);
+                        setNewGroupName("");
+                      }
+                    }}
+                    className="w-full border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="새 그룹 이름"
+                    autoFocus
+                  />
+                </li>
+              ) : (
+                <li
+                  className="flex items-center px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm text-blue-600"
+                  onClick={() => setIsAddingGroup(true)}
+                >
+                  <Plus size={14} className="mr-2" />
+                  새로 만들기
+                </li>
+              )}
             </ul>
           </div>
         )}
@@ -176,4 +268,3 @@ export const DeviceFilter = ({
     </div>
   );
 };
-


### PR DESCRIPTION
# Changelog
- `DeviceFilter`에 그룹 / 리전을 생성하는 기능을 추가하였습니다.
  - 드롭다운 최하단에, `+ 추가하기` 버튼을 누르면 생성 가능하도록 하였습니다.
    - 그룹 추가: `POST /api/groups`
    - 리전 추가: `POST /api/regions`
- 백엔드에서 펌웨어 다운로드 요청 엔드포인트가 `/api/s3/firmware/presigned_download` 에서 `/api/s3/firmware/download` 로 변경되어 동기화하였습니다.

# Testing
<img width="459" height="399" alt="image" src="https://github.com/user-attachments/assets/b726c8e3-4c86-47f8-b8d6-957b3ed2f88d" />

<img width="449" height="372" alt="image" src="https://github.com/user-attachments/assets/b4fe0284-e261-4265-9639-dee1516d5512" />

# Ops Impact
N/A

# Version Compatibility
N/A