### PR TITLE
[Frontend] 광고 배포 API 요청 오류 수정

### DIFF
--- a/frontend/src/entities/device/model/types.ts
+++ b/frontend/src/entities/device/model/types.ts
@@ -4,7 +4,7 @@ import { PaginationMeta } from "../../../shared/api/types";
  * 기기(Device) 정보를 나타내는 인터페이스입니다.
  */
 export interface Device {
-  deviceId: string;
+  deviceId: number;
   deviceName: string;
   regionName: string;
   groupName: string;

--- a/frontend/src/features/ad_deploy/api/api.ts
+++ b/frontend/src/features/ad_deploy/api/api.ts
@@ -18,9 +18,9 @@ import { deviceApiService } from "../../../entities/device/api/api";
 export interface AdDeployRequest {
   adIds: number[];
   deploymentType: DeploymentType;
-  regions?: Region[];
-  groups?: Group[];
-  devices?: Device[];
+  regions?: number[];
+  groups?: number[];
+  devices?: number[];
 }
 
 /**
@@ -28,7 +28,7 @@ export interface AdDeployRequest {
  * @param {AdDeployRequest} request - 배포 요청 데이터
  */
 export const deployAds = async (request: AdDeployRequest) => {
-  const response = await apiClient.post("/ad-deployments", request);
+  const response = await apiClient.post("/api/ads/deployment", request);
   return response.data;
 };
 

--- a/frontend/src/features/ad_deploy/api/useAdDeploy.tsx
+++ b/frontend/src/features/ad_deploy/api/useAdDeploy.tsx
@@ -3,7 +3,6 @@ import { AdDeployRequest, deployAds } from "./api";
 
 /**
  * useAdDeploy 훅은 광고 배포 요청을 처리하는 뮤테이션 훅입니다.
- * @returns {UseMutationResult} 광고 배포 요청을 처리하는 뮤테이션 객체
  */
 export const useAdDeploy = () => {
   return useMutation({

--- a/frontend/src/features/ad_deploy/ui/AdDeploy.tsx
+++ b/frontend/src/features/ad_deploy/ui/AdDeploy.tsx
@@ -195,9 +195,9 @@ export const AdDeploy = ({ ads, onClose }: AdDeployProps): JSX.Element => {
         deployAds({
           adIds: ads.map((ad) => ad.id),
           deploymentType,
-          regions: selectedRegions,
-          groups: selectedGroups,
-          devices: selectedDevices,
+          regions: selectedRegions.map((r) => r.regionId),
+          groups: selectedGroups.map((g) => g.groupId),
+          devices: selectedDevices.map((d) => d.deviceId),
         }),
         {
           pending: "배포 요청 중...",


### PR DESCRIPTION
# Changelog
기존에 광고 API를 호출할 때 리전, 그룹, 기기의 ID 를 리스트로 보내는 것이 아니라 Object 자체를 보내고 있었습니다.. ㅎㅎ

- 광고 배포 API 요청을 보낼 때 리전, 그룹, 기기의 ID만 추출하여 배열로 보내도록 수정하였습니다.
- 임의로 지정해두었던 광고 배포 API가 확정됨에 따라 `/api/ads/deployment` 에 연결하였습니다.

# Testing
시뮬레이터로 테스트 - `deviceId=1` 로 실행하고, 광고 배포 요청

```
2025-09-11 00:05:51 [INFO] Successfully published to topic 'v1/1/update/result' with payload: {"command_id": "AD-195b224f-70d0-4266-a84b-9c60f03062ae", "status": "SUCCESS", "message": "All advertisement contents downloaded successfully.", "checksum_verified": true, "download_ms": 710, "timestamp": "2025-09-10T15:05:51.755964Z"}
```

# Ops Impact
N/A

# Version Compatibility
N/A