### PR TITLE
[Mqtt Handler] 대량 배포 시 MQTT 연결이 끊어지는 현상 해결

### DIFF
--- a/mqtt-handler/init/cmd/cmd.go
+++ b/mqtt-handler/init/cmd/cmd.go
@@ -23,7 +23,6 @@ type Cmd struct {
 func NewCmd() *Cmd {
 	c := &Cmd{
 		config:        config.NewConfig(),
-		network:       network.NewNetwork(),
 		mqttClient:    mqttclient.NewMqttClient(),
 		questDBClient: repository.NewDBClient(),
 	}
@@ -37,6 +36,9 @@ func NewCmd() *Cmd {
 
 	// MQTT 연결
 	c.mqttClient.Connect(c.config.MqttBroker.Url, c.config.MqttBroker.ClientId)
+
+	// network 초기화 - MQTT 클라이언트를 주입합니다.
+	c.network = network.NewNetwork(c.mqttClient)
 
 	// HTTP 서버 시작
 	if err := c.network.ServerStart(c.config.Server.Port); err != nil {

--- a/mqtt-handler/mqttclient/publisher.go
+++ b/mqtt-handler/mqttclient/publisher.go
@@ -7,14 +7,13 @@ import (
 	"log"
 	"mqtt-handler/repository"
 	"mqtt-handler/types"
-	"sync"
+	"time"
 )
 
 // MQTT 클라이언트를 사용해 지정된 토픽으로 JSON 형태의 펌웨어 배포 요청 메시지를 전송합니다.
 func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 	var buf bytes.Buffer
 
-	var wg sync.WaitGroup
 	command := types.FirmwareDownloadCommand{
 		CommandID: req.CommandId,
 		Content:   req.Content,
@@ -29,18 +28,14 @@ func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 	}
 	payload := buf.String()
 
-	for _, deviceInfo := range req.Devices {
-		wg.Add(1)
-
-		deviceInfoCopy := deviceInfo
-		go func(d types.DeviceIds) {
-			defer wg.Done()
-			topic := fmt.Sprintf("v1/%d/update/request/firmware", d.DeviceId)
-			token := m.mqttClient.Publish(topic, 2, false, payload)
+	go func() {
+		for _, deviceInfo := range req.Devices {
+			topic := fmt.Sprintf("v1/%d/update/request/firmware", deviceInfo.DeviceId)
+			token := m.mqttClient.Publish(topic, 1, false, payload)
 
 			event := types.DownloadEvent{
 				CommandID:        command.CommandID,
-				DeviceID:         d.DeviceId,
+				DeviceID:         deviceInfo.DeviceId,
 				Message:          "Download Command",
 				Status:           "WAITING",
 				Progress:         0,
@@ -56,16 +51,13 @@ func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-		}(deviceInfoCopy)
-	}
-
-	wg.Wait()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
 }
 
 // MQTT 클라이언트를 사용해 지정된 토픽으로 JSON 형태의 펌웨어 배포 취소 요청 메시지를 전송합니다.
 func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest) {
-	var wg sync.WaitGroup
-
 	command := types.DownloadCancelCommand{
 		CommandID: req.CommandID,
 		Reason:    req.Reason,
@@ -78,18 +70,14 @@ func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest
 		return
 	}
 
-	for _, deviceInfo := range req.Devices {
-		wg.Add(1)
-
-		deviceInfoCopy := deviceInfo
-		go func(d types.DeviceIds) {
-			defer wg.Done()
-			topic := fmt.Sprintf("v1/%d/update/cancel", d.DeviceId)
+	go func() {
+		for _, deviceInfo := range req.Devices {
+			topic := fmt.Sprintf("v1/%d/update/cancel", deviceInfo.DeviceId)
 			token := m.mqttClient.Publish(topic, 2, false, payload)
 
 			event := types.DownloadEvent{
 				CommandID:        command.CommandID,
-				DeviceID:         d.DeviceId,
+				DeviceID:         deviceInfo.DeviceId,
 				Message:          command.Reason,
 				Status:           "CANCELED",
 				Progress:         0,
@@ -105,16 +93,14 @@ func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-		}(deviceInfoCopy)
-	}
-
-	wg.Wait()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
 }
 
 func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 	var buf bytes.Buffer
 
-	var wg sync.WaitGroup
 	command := types.AdsDownloadCommand{
 		CommandID: req.CommandId,
 		Contents:  req.Contents,
@@ -134,18 +120,14 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 	}
 	payload := buf.String()
 
-	for _, deviceInfo := range req.Devices {
-		wg.Add(1)
-
-		deviceInfoCopy := deviceInfo
-		go func(d types.DeviceIds) {
-			defer wg.Done()
-			topic := fmt.Sprintf("v1/%d/update/request/advertisement", d.DeviceId)
+	go func() {
+		for _, deviceInfo := range req.Devices {
+			topic := fmt.Sprintf("v1/%d/update/request/advertisement", deviceInfo.DeviceId)
 			token := m.mqttClient.Publish(topic, 2, false, payload)
 
 			event := types.DownloadEvent{
 				CommandID:        command.CommandID,
-				DeviceID:         d.DeviceId,
+				DeviceID:         deviceInfo.DeviceId,
 				Message:          "Download Command",
 				Status:           "WAITING",
 				Progress:         0,
@@ -161,8 +143,7 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-		}(deviceInfoCopy)
-	}
-
-	wg.Wait()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
 }

--- a/mqtt-handler/mqttclient/publisher.go
+++ b/mqtt-handler/mqttclient/publisher.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const publishDelay = 10 * time.Millisecond
+
 // MQTT 클라이언트를 사용해 지정된 토픽으로 JSON 형태의 펌웨어 배포 요청 메시지를 전송합니다.
 func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 	var buf bytes.Buffer
@@ -51,7 +53,7 @@ func (m *MQTTClient) PublishDownloadRequest(req *types.FirmwareDeployRequest) {
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(publishDelay)
 		}
 	}()
 }
@@ -93,7 +95,7 @@ func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(publishDelay)
 		}
 	}()
 }
@@ -143,7 +145,7 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 			if token.Error() != nil {
 				log.Printf("[MQTT] Publish 실패: %s → %v", topic, token.Error())
 			}
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(publishDelay)
 		}
 	}()
 }

--- a/mqtt-handler/network/advertisement.go
+++ b/mqtt-handler/network/advertisement.go
@@ -6,13 +6,6 @@ import (
 	"mqtt-handler/mqttclient"
 	"mqtt-handler/types"
 	"net/http"
-	"sync"
-)
-
-// advertisementRouterInit: advertisementRouter 싱글톤 초기화를 위한 sync.Once
-var (
-	advertisementRouterInit     sync.Once
-	advertisementRouterInstance *advertisementRouter
 )
 
 // advertisementRouter: 광고 배포 관련 라우팅 로직을 담당하는 구조체
@@ -21,17 +14,15 @@ type advertisementRouter struct {
 	mqttClient *mqttclient.MQTTClient
 }
 
-// advertisementRouter를 한 번만 초기화하고, 요청 경로에 대한 핸들러를 등록합니다.
-func newAdsRouter(router *Network) *advertisementRouter {
-	advertisementRouterInit.Do(func() {
-		advertisementRouterInstance = &advertisementRouter{
-			router:     router,
-			mqttClient: mqttclient.NewMqttClient(),
-		}
-		router.adsDeployPOST("/api/advertisements/deployment", advertisementRouterInstance.sendAdvertisement)
-	})
+// advertisementRouter를 초기화하고, 요청 경로에 대한 핸들러를 등록합니다.
+func newAdsRouter(router *Network, mqttClient *mqttclient.MQTTClient) *advertisementRouter {
+	adsRouter := &advertisementRouter{
+		router:     router,
+		mqttClient: mqttClient,
+	}
+	router.adsDeployPOST("/api/advertisements/deployment", adsRouter.sendAdvertisement)
 
-	return advertisementRouterInstance
+	return adsRouter
 }
 
 // 광고 배포 요청을 처리하는 핸들러 함수

--- a/mqtt-handler/network/firmware.go
+++ b/mqtt-handler/network/firmware.go
@@ -6,14 +6,6 @@ import (
 	"mqtt-handler/mqttclient"
 	"mqtt-handler/types"
 	"net/http"
-	"sync"
-)
-
-// firmwareRouterInit: firmwareRouter 싱글톤 초기화를 위한 sync.Once
-// firmwareRouterInstance: 실제 싱글톤 인스턴스
-var (
-	firmwareRouterInit     sync.Once
-	firmwareRouterInstance *firmwareRouter
 )
 
 // 펌웨어 배포 관련 라우팅 로직을 담당하는 구조체
@@ -22,19 +14,16 @@ type firmwareRouter struct {
 	mqttClient *mqttclient.MQTTClient
 }
 
-// firmwareRouter를 한 번만 초기화하고, 요청 경로에 대한 핸들러를 등록합니다.
-func newFirmwareRouter(router *Network) *firmwareRouter {
-	firmwareRouterInit.Do(func() {
-		firmwareRouterInstance = &firmwareRouter{
-			router:     router,
-			mqttClient: mqttclient.NewMqttClient(),
-		}
-		router.firmwareDeployPOST("/api/firmwares/deployment", firmwareRouterInstance.firmwareDeploy)
-		router.firmwareDeployPOST("/api/firmwares/deployment/cancel", firmwareRouterInstance.cancelFirmwareDeploy)
+// firmwareRouter를 초기화하고, 요청 경로에 대한 핸들러를 등록합니다.
+func newFirmwareRouter(router *Network, mqttClient *mqttclient.MQTTClient) *firmwareRouter {
+	fRouter := &firmwareRouter{
+		router:     router,
+		mqttClient: mqttClient,
+	}
+	router.firmwareDeployPOST("/api/firmwares/deployment", fRouter.firmwareDeploy)
+	router.firmwareDeployPOST("/api/firmwares/deployment/cancel", fRouter.cancelFirmwareDeploy)
 
-	})
-
-	return firmwareRouterInstance
+	return fRouter
 }
 
 // 클라이언트의 펌웨어 배포 요청을 처리하는 엔드포인트입니다.

--- a/mqtt-handler/network/root.go
+++ b/mqtt-handler/network/root.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"log"
+	"mqtt-handler/mqttclient"
 	"net/http"
 )
 
@@ -12,13 +13,13 @@ type Network struct {
 }
 
 // 새로운 Network 인스턴스를 생성하고 펌웨어 배포 요청을 처리할 라우팅 경로를 등록합니다.
-func NewNetwork() *Network {
+func NewNetwork(mqttClient *mqttclient.MQTTClient) *Network {
 	net := &Network{
 		mux: http.NewServeMux(),
 	}
 
-	newFirmwareRouter(net)
-	newAdsRouter(net)
+	newFirmwareRouter(net, mqttClient)
+	newAdsRouter(net, mqttClient)
 	return net
 }
 


### PR DESCRIPTION
# Changelog
- 펌웨어, 광고를 배포 시 `Wait Group`으로 동시에 Publish하지 않고, 시간 간격(10ms)를 두어 Publish 하도록 변경하였습니다.
- 펌웨어, 광고 배포 메시지 QoS를 2에서 1로 변경하였습니다.
- `network`의 `newFirmwareRouter`, `newAdsRouter`에서 `mqtt.NewMqttClient()`를 사용하면 싱글톤을 위반하여 중복된 Client ID가 생성될 수 있으므로 `root.go`에서 생성된 싱글톤 MQTT Client를 주입하는 방법으로 변경하였습니다.

# Testing
- 1000개의 메시지 Publish 이후 `Connect Lost: EOF` 오류 발생 여부 확인
<img width="861" height="317" alt="image" src="https://github.com/user-attachments/assets/b552dd31-bff7-48ac-a6d0-a077ac2c88bc" />

# Ops Impact
N/A

# Version Compatibility
N/A