### PR TITLE
[Mqtt Handler] 고루틴 동시 사용 문제 해결을 위해 Consumer별 DBClient 분리

### DIFF
--- a/mqtt-handler/mqttclient/client.go
+++ b/mqtt-handler/mqttclient/client.go
@@ -34,9 +34,7 @@ var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err
 // NewMqttClient는 MQTTClient 인스턴스를 한 번만 생성합니다.
 func NewMqttClient() *MQTTClient {
 	mqttClientInit.Do(func() {
-		mqttClientInstance = &MQTTClient{
-			dbClient: repository.NewDBClient(),
-		}
+		mqttClientInstance = &MQTTClient{}
 	})
 
 	return mqttClientInstance
@@ -52,9 +50,9 @@ func (m *MQTTClient) Connect(brokerURL string, clientId string) {
 
 	// 안정성 튜닝
 	opts.SetKeepAlive(30 * time.Second)
-	opts.SetPingTimeout(10 * time.Second)
-	opts.SetWriteTimeout(10 * time.Second)
-	opts.SetConnectTimeout(10 * time.Second)
+	opts.SetPingTimeout(30 * time.Second)
+	opts.SetWriteTimeout(30 * time.Second)
+	opts.SetConnectTimeout(30 * time.Second)
 
 	// 끊겨도 자동 복구
 	opts.SetAutoReconnect(true)

--- a/mqtt-handler/repository/questdb_repository.go
+++ b/mqtt-handler/repository/questdb_repository.go
@@ -2,17 +2,9 @@ package repository
 
 import (
 	"context"
+	"github.com/questdb/go-questdb-client/v3"
 	"log"
 	"mqtt-handler/types"
-	"sync"
-
-	"github.com/questdb/go-questdb-client/v3"
-)
-
-// DB 클라이언트 싱글톤 초기화를 위한 sync.Once 및 인스턴스
-var (
-	questDBClientInit     sync.Once
-	questDBClientInstance *DBClient
 )
 
 // 다운로드 이벤트 처리를 위한 비동기 채널
@@ -32,22 +24,12 @@ type DBClient struct {
 	sender questdb.LineSender
 }
 
-// 싱글톤 패턴으로 DBClient 인스턴스를 한 번만 생성합니다.
-func NewDBClient() *DBClient {
-	questDBClientInit.Do(func() {
-		questDBClientInstance = &DBClient{}
-	})
-	return questDBClientInstance
-}
-
-// QuestDB에 연결을 수행하고, 연결 성공 시 LineSender를 초기화합니다.
-func (c *DBClient) Connect(ctx context.Context, configStr string) error {
-	sender, err := questdb.LineSenderFromConf(ctx, configStr)
+// DBClient 생성자
+func NewDBClient(ctx context.Context, confStr string) *DBClient {
+	sender, err := questdb.LineSenderFromConf(ctx, confStr)
 	if err != nil {
-		log.Fatalf("[QuestDB] 연결 실패")
-		return err
+		log.Fatalf("[QuestDB] 연결 실패: %v", err)
 	}
-	c.sender = sender
 	log.Println("[QuestDB] 연결 완료")
-	return nil
+	return &DBClient{sender: sender}
 }


### PR DESCRIPTION
# Changelog

- LineSender 고루틴 동시 사용으로 인한 데이터 섞임/파싱 에러 수정
- Consumer별 독립 DBClient 생성하여 안전하게 QuestDB에 저장하도록 변경

# Testing

- MQTT 메시지 수신 후 QuestDB 테이블별 데이터 정상 적재 확인
- system_status, download_events 등 테이블 데이터가 섞이지 않음 확인

# Ops Impact

N/A

# Version Compatibility

N/A