### PR TITLE
[Backend] 페이지네이션 안정성을 위해 createdAt + deviceId 정렬 기준 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -154,7 +154,11 @@ public class DeviceService {
      * @return DeviceListResponseDto (디바이스 목록과 페이지 메타데이터)
      */
     public DeviceListResponseDto findAllDevices(Long regionId, Long groupId, PaginationInfo paginationInfo) {
-        Pageable pageable = PageRequest.of(paginationInfo.page() - 1, paginationInfo.limit(), Sort.by("createdAt").ascending());
+        Pageable pageable = PageRequest.of(
+                paginationInfo.page() - 1,
+                paginationInfo.limit(),
+                Sort.by("createdAt").ascending().and(Sort.by("id").ascending())
+        );
         Page<Device> devicesPage = deviceJpaRepository.findByRegionAndGroup(regionId, groupId, pageable);
         List<Device> content = devicesPage.getContent();
 


### PR DESCRIPTION
# Changelog

- 페이지네이션 안정성을 위해 createdAt + deviceId 정렬 기준 추가

# Testing

- 디바이스 리스트 API 호출 시 중복/누락 없이 정상적으로 페이지네이션 동작 확인
<img width="577" height="530" alt="image" src="https://github.com/user-attachments/assets/4906c171-74a5-4c62-8fb6-ec5769362edd" />

<img width="634" height="642" alt="image" src="https://github.com/user-attachments/assets/2fffc8dc-334b-4d90-9ac1-c820e2388641" />

# Ops Impact

N/A

# Version Compatibility

N/A
