### PR TITLE
[Backend/Mqtt Handler] 기기 등록 코드 발급 API 및 MQTT regist/ack 토픽 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/DeviceController.java
@@ -1,10 +1,9 @@
 package com.coffee_is_essential.iot_cloud_ota.controller;
 
 import com.coffee_is_essential.iot_cloud_ota.domain.PaginationInfo;
-import com.coffee_is_essential.iot_cloud_ota.dto.DeviceDetailResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.DeviceListResponseDto;
-import com.coffee_is_essential.iot_cloud_ota.dto.DeviceSummaryResponseDto;
+import com.coffee_is_essential.iot_cloud_ota.dto.*;
 import com.coffee_is_essential.iot_cloud_ota.service.DeviceService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -68,6 +67,32 @@ public class DeviceController {
     @GetMapping("{id}")
     public ResponseEntity<DeviceDetailResponseDto> findDetailByDeviceId(@PathVariable Long id) {
         DeviceDetailResponseDto responseDto = deviceService.findDetailByDeviceId(id);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    /**
+     * 새로운 디바이스를 등록합니다.
+     *
+     * @param requestDto 디바이스 등록에 필요한 정보를 담은 DeviceRegisterRequestDto
+     * @return 등록된 디바이스의 정보를 담은 DeviceRegisterResponseDto와 HTTP 200 응답
+     */
+    @PostMapping
+    public ResponseEntity<GenerateRegistrationCodeResponseDto> generateRegisterCode(@Valid @RequestBody GenerateRegistrationCodeRequestDto requestDto) {
+        GenerateRegistrationCodeResponseDto responseDto = deviceService.generateCode(requestDto);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    /**
+     * 디바이스 등록 코드를 사용하여 디바이스를 등록합니다.
+     *
+     * @param requestDto 디바이스 등록에 필요한 정보를 담은 DeviceRegisterRequestDto
+     * @return 등록된 디바이스의 정보를 담은 DeviceRegisterResponseDto와 HTTP 200 응답
+     */
+    @PostMapping("/register")
+    public ResponseEntity<DeviceRegisterResponseDto> registerDevice(@Valid @RequestBody DeviceRegisterRequestDto requestDto) {
+        DeviceRegisterResponseDto responseDto = deviceService.registerDevice(requestDto);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsDeploymentDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsDeploymentDto.java
@@ -8,18 +8,21 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
- * 광고 배포에 필요한 정보를 담고 있는 DTO입니다.
+ * AdsDeploymentDto는 ADS(Automated Deployment System) 배포 요청에 대한 데이터를 담는 DTO입니다.
+ * 이 DTO는 배포 명령 ID, 배포할 콘텐츠 목록, 대상 디바이스 정보, 총 콘텐츠 크기, 타임스탬프를 포함합니다.
  *
- * @param commandId 배포 명령 ID
- * @param contents  배포할 광고 콘텐츠 정보 목록 (Signed URL 및 메타데이터 포함)
- * @param devices   배포 대상 디바이스 정보 목록
- * @param timestamp 배포 요청 시각
+ * @param commandId 배포 명령의 고유 ID
+ * @param contents  배포할 콘텐츠의 리스트
+ * @param devices   배포 대상 디바이스의 정보 리스트
+ * @param totalSize 배포할 콘텐츠의 총 크기 (바이트 단위)
+ * @param timestamp 배포 요청이 생성된 시각
  */
 public record AdsDeploymentDto(
         @JsonProperty("command_id")
         String commandId,
         List<DeploymentContent> contents,
         List<DeployTargetDeviceInfo> devices,
+        long totalSize,
         OffsetDateTime timestamp
 ) {
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceRegisterRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceRegisterRequestDto.java
@@ -1,0 +1,23 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DeviceRegisterRequestDto(
+        @NotNull(message = "device id는 필수 값입니다.")
+        @JsonProperty("device_id")
+        Long deviceId,
+
+        @NotBlank(message = "device name은 필수 값입니다.")
+        @JsonProperty("device_name")
+        String deviceName,
+
+        @NotBlank(message = "AuthKey는 필수 값입니다.")
+        @JsonProperty("auth_key")
+        String AuthKey,
+
+        @NotBlank(message = "timestamp는 필수 값입니다.")
+        String timestamp
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceRegisterResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DeviceRegisterResponseDto.java
@@ -1,0 +1,9 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import java.time.OffsetDateTime;
+
+public record DeviceRegisterResponseDto(
+        String status,
+        OffsetDateTime timestamp
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/GenerateRegistrationCodeRequestDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/GenerateRegistrationCodeRequestDto.java
@@ -1,0 +1,11 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GenerateRegistrationCodeRequestDto(
+        @NotNull(message = "region id는 필수 값입니다.")
+        Long regionId,
+        @NotNull(message = "group id는 필수 값입니다.")
+        Long groupId
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/GenerateRegistrationCodeResponseDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/GenerateRegistrationCodeResponseDto.java
@@ -1,0 +1,7 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+public record GenerateRegistrationCodeResponseDto(
+        String code,
+        String expiresAt
+) {
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Device.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/entity/Device.java
@@ -1,6 +1,7 @@
 package com.coffee_is_essential.iot_cloud_ota.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,9 +11,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "device")
 @NoArgsConstructor
+@AllArgsConstructor
 public class Device extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeviceService.java
@@ -10,12 +10,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 @Service
 @AllArgsConstructor
@@ -30,18 +34,21 @@ public class DeviceService {
     private final DeviceFirmwareJpaRepository deviceFirmwareJpaRepository;
     private final DeviceAdsJpaRepository deviceAdsJpaRepository;
     private final CloudFrontSignedUrlService cloudFrontSignedUrlService;
+    private static int TIMEOUT = 5;
+    private final StringRedisTemplate srt;
 
     /**
-     * 새로운 디바이스를 생성하고 저장합니다.
+     * 새로운 디바이스를 저장합니다.
      *
+     * @param deviceId   디바이스 ID
      * @param deviceName 디바이스 이름
-     * @param regionId   연결할 리전의 ID
-     * @param divisionId 연결할 디비전의 ID
+     * @param regionId   디바이스가 속한 리전 ID
+     * @param divisionId 디바이스가 속한 그룹 ID
      */
-    public void saveDevice(String deviceName, Long regionId, Long divisionId) {
+    public void saveDevice(Long deviceId, String deviceName, Long regionId, Long divisionId) {
         Region region = regionJpaRepository.findByIdOrElseThrow(regionId);
         Division division = divisionJpaRepository.findByIdOrElseThrow(divisionId);
-        Device device = new Device(deviceName, division, region);
+        Device device = new Device(deviceId, deviceName, division, region);
 
         deviceJpaRepository.save(device);
     }
@@ -214,5 +221,81 @@ public class DeviceService {
                         )
                         .toList()
         );
+    }
+
+    /**
+     * 디바이스 등록 요청을 처리합니다.
+     * 요청된 리전과 그룹에 대한 유효성을 검증하고, 6자리 숫자로 구성된 디바이스 코드를 생성합니다.
+     * 생성된 디바이스 코드는 Redis에 저장되며, 만료 시간은 5분으로 설정됩니다.
+     * 최종적으로 디바이스 코드와 만료 시간을 포함한 응답 DTO를 반환합니다.
+     *
+     * @param requestDto 디바이스 등록 요청 DTO
+     * @return DeviceRegisterResponseDto (생성된 디바이스 코드와 만료 시간)
+     */
+    @Transactional
+    public GenerateRegistrationCodeResponseDto generateCode(GenerateRegistrationCodeRequestDto requestDto) {
+        Region region = regionJpaRepository.findByIdOrElseThrow(requestDto.regionId());
+        Division group = divisionJpaRepository.findByIdOrElseThrow(requestDto.groupId());
+        String code = generateRandomCode();
+        String expiresAt = Instant.now().plus(Duration.ofMinutes(TIMEOUT)).toString();
+        saveRedisDeviceCode(code, region.getId(), group.getId());
+        return new GenerateRegistrationCodeResponseDto(code, expiresAt);
+    }
+
+    /**
+     * Redis에 디바이스 등록 코드를 저장합니다.
+     * 저장된 코드는 지정된 시간(5분) 후에 만료됩니다.
+     *
+     * @param code     저장할 디바이스 코드
+     * @param regionId 디바이스가 속할 리전의 ID
+     * @param groupId  디바이스가 속할 그룹의 ID
+     */
+    private void saveRedisDeviceCode(String code, Long regionId, Long groupId) {
+        String redisKey = "device:register:" + code;
+        String redisValue = String.format("{\"regionId\": %d, \"groupId\": %d}",
+                regionId, groupId);
+
+        srt.opsForValue().set(redisKey, redisValue, Duration.ofMinutes(TIMEOUT));
+    }
+
+    /**
+     * 디바이스 등록 요청을 처리합니다.
+     * 요청된 인증 키를 Redis에서 조회하여 유효성을 검증하고, 해당 정보에 기반하여 디바이스를 저장합니다.
+     * 인증 키가 유효하지 않은 경우 "AUTH_FAILED" 상태를 반환하며, 유효한 경우 "OK" 상태와 함께 현재 시간을 반환합니다.
+     *
+     * @param requestDto 디바이스 등록 요청 DTO
+     * @return DeviceRegisterResponseDto (등록 상태와 현재 시간)
+     */
+    @Transactional
+    public DeviceRegisterResponseDto registerDevice(DeviceRegisterRequestDto requestDto) {
+        String redisKey = "device:register:" + requestDto.AuthKey();
+        String redisValue = srt.opsForValue().get(redisKey);
+
+        if (redisValue == null) {
+            return new DeviceRegisterResponseDto("AUTH_FAILED", OffsetDateTime.now());
+        }
+
+        Long regionId = Long.valueOf(redisValue.replaceAll(".*\"regionId\": (\\d+),.*", "$1"));
+        Long groupId = Long.valueOf(redisValue.replaceAll(".*\"groupId\": (\\d+)}.*", "$1"));
+
+        saveDevice(requestDto.deviceId(), requestDto.deviceName(), regionId, groupId);
+
+        return new DeviceRegisterResponseDto("OK", OffsetDateTime.now());
+    }
+
+    /**
+     * 6자리 숫자로 구성된 디바이스 코드를 생성합니다.
+     *
+     * @return 생성된 디바이스 코드
+     */
+    private String generateRandomCode() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            sb.append(random.nextInt(10)); // 0~9
+        }
+
+        return sb.toString();
     }
 }

--- a/mqtt-handler/config/config.go
+++ b/mqtt-handler/config/config.go
@@ -6,11 +6,14 @@ import (
 	"os"
 )
 
+var SpringUrl string
+
 // 환경 변수로부터 읽어들일 설정값의 구조를 정의합니다.
 type Config struct {
 	Server struct {
 		Port string
 	}
+
 	MqttBroker struct {
 		Url      string
 		ClientId string
@@ -18,6 +21,10 @@ type Config struct {
 
 	QuestDB struct {
 		Conf string
+	}
+
+	Spring struct {
+		Url string
 	}
 }
 
@@ -29,6 +36,7 @@ func NewConfig() *Config {
 	conf.MqttBroker.Url = getEnv("MQTT_BROKER_URL", "tcp://localhost:1883")
 	conf.MqttBroker.ClientId = getEnv("MQTT_CLIENT_ID", "mqtt-handler")
 	conf.QuestDB.Conf = getEnv("QUESTDB_CONF", "http::addr=localhost:9000")
+	SpringUrl = getEnv("SPRING_URL", "http://localhost:8080")
 
 	return conf
 }

--- a/mqtt-handler/mqttclient/client.go
+++ b/mqtt-handler/mqttclient/client.go
@@ -90,4 +90,5 @@ func (m *MQTTClient) SubscribeAllTopics() {
 	m.subscribeSystemStatus("v1/+/status/system", parseSystemStatus, "[SYSTEM STATUS]")
 	m.subscribeErrorLog("v1/+/status/error_log", parseErrorLog, "[ERROR LOG]")
 	m.subscribeSalesData("v1/+/sales/data", parseSalesItem, "[SALES DATA]")
+	m.subscribeDeviceRegister("v1/+/regist", "[DEVICE REGISTER]")
 }

--- a/mqtt-handler/mqttclient/device_subscriber.go
+++ b/mqtt-handler/mqttclient/device_subscriber.go
@@ -1,0 +1,72 @@
+package mqttclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"io"
+	"log"
+	"mqtt-handler/config"
+	"mqtt-handler/types"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+var httpClient = &http.Client{}
+
+// subscribeDeviceRegister는 디바이스 등록 요청을 구독하고 처리합니다.
+func (m *MQTTClient) subscribeDeviceRegister(topic string, label string) {
+	handler := func(client mqtt.Client, msg mqtt.Message) {
+
+		var req types.DeviceRegisterRequest
+		if err := json.Unmarshal(msg.Payload(), &req); err != nil {
+			log.Printf("[ERROR] %s 메시지 파싱 실패: %v", label, err)
+			return
+		}
+
+		topicParts := strings.Split(msg.Topic(), "/")
+		deviceId, _ := strconv.ParseInt(topicParts[1], 10, 64)
+
+		req.DeviceId = deviceId
+
+		go forwardToSpring(&req, m)
+	}
+
+	token := m.mqttClient.Subscribe(topic, 1, handler)
+	token.Wait()
+	if token.Error() != nil {
+		log.Printf("[ERROR] %s 구독 실패: %v", label, token.Error())
+	} else {
+		log.Printf("[MQTT] 구독 성공: %s", topic)
+	}
+}
+
+// Spring 서버로 디바이스 등록 요청을 전달합니다.
+func forwardToSpring(req *types.DeviceRegisterRequest, m *MQTTClient) {
+	url := config.SpringUrl + "/api/devices/register"
+	jsonData, _ := json.Marshal(req)
+
+	resp, err := httpClient.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Printf("[ERROR] Spring 전송 실패 (deviceId=%d): %v", req.DeviceId, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	var springResp types.DeviceRegisterResponse
+	if err := json.Unmarshal(body, &springResp); err != nil {
+		log.Printf("[ERROR] 응답 파싱 실패: %v", err)
+		return
+	}
+	
+	ackTopic := fmt.Sprintf("v1/%d/regist/ack", req.DeviceId)
+	ackPayload, _ := json.Marshal(springResp)
+
+	if token := m.mqttClient.Publish(ackTopic, 1, false, ackPayload); token.Wait() && token.Error() != nil {
+		log.Printf("[ERROR] MQTT publish 실패 (topic=%s, deviceId=%d): %v", ackTopic, req.DeviceId, token.Error())
+	}
+}

--- a/mqtt-handler/mqttclient/publisher.go
+++ b/mqtt-handler/mqttclient/publisher.go
@@ -101,6 +101,7 @@ func (m *MQTTClient) PublishDownloadCancelRequest(req *types.DeployCancelRequest
 	}()
 }
 
+// MQTT 클라이언트를 사용해 지정된 토픽으로 JSON 형태의 광고 배포 요청 메시지를 전송합니다.
 func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 	var buf bytes.Buffer
 
@@ -108,11 +109,7 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 		CommandID: req.CommandId,
 		Contents:  req.Contents,
 		Timestamp: req.Timestamp,
-	}
-
-	totalSize := 0
-	for _, content := range req.Contents {
-		totalSize += int(content.FileInfo.Size)
+		TotalSize: req.TotalSize,
 	}
 
 	enc := json.NewEncoder(&buf)
@@ -133,7 +130,7 @@ func (m *MQTTClient) PublishAdsDownloadRequest(req *types.AdsDeployRequest) {
 				Message:          "Download Command",
 				Status:           "WAITING",
 				Progress:         0,
-				TotalBytes:       int64(totalSize),
+				TotalBytes:       command.TotalSize,
 				DownloadBytes:    0,
 				SpeedKbps:        0,
 				ChecksumVerified: false,

--- a/mqtt-handler/types/advertisement.go
+++ b/mqtt-handler/types/advertisement.go
@@ -6,6 +6,7 @@ type AdsDeployRequest struct {
 	CommandId string      `json:"command_id"`
 	Contents  []Content   `json:"contents"`
 	Devices   []DeviceIds `json:"devices"`
+	TotalSize int64       `json:"totalSize"`
 	Timestamp time.Time   `json:"timestamp"`
 }
 
@@ -33,4 +34,5 @@ type AdsDownloadCommand struct {
 	CommandID string    `json:"command_id"`
 	Contents  []Content `json:"contents"`
 	Timestamp time.Time `json:"timestamp"`
+	TotalSize int64     `json:"total_size"`
 }

--- a/mqtt-handler/types/device.go
+++ b/mqtt-handler/types/device.go
@@ -1,0 +1,15 @@
+package types
+
+import "time"
+
+type DeviceRegisterRequest struct {
+	DeviceId   int64     `json:"device_id"`
+	DeviceName string    `json:"device_name"`
+	AuthKey    string    `json:"auth_key"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
+type DeviceRegisterResponse struct {
+	Status    string    `json:"status"`
+	Timestamp time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
# Changelog

- `POST /api/devices` 기기 등록 코드 발급 API 추가
- 광고 배포 시 MQTT 메시지에 `total_size` 필드 포함
- 기기 등록용 MQTT 토픽(`v1/{deviceId}/regist`) 구독 및 Spring 연동
- 등록 결과를 `v1/{deviceId}/regist/ack` 토픽으로 publish

# Testing

- 기기 등록 코드 발급 API 호출 시 정상적으로 코드와 만료 시간 반환 확인
<img width="448" height="485" alt="image" src="https://github.com/user-attachments/assets/f0baedd7-b6fd-40b2-998f-08f5d2cba58c" />

- 광고 배포 메시지에 total_size 값 포함 여부 확인
<img width="822" height="153" alt="image" src="https://github.com/user-attachments/assets/a2d2f218-1799-461a-b05f-b3716360512f" />

- MQTT 구독/발행 흐름 (regist → Spring 검증 → regist/ack) 정상 동작 검증
- 기기 등록 후 DB 저장 확인
<img width="1108" height="66" alt="image" src="https://github.com/user-attachments/assets/1daaf415-bd3c-4c60-a670-fe4ae6316cd5" />

<img width="1010" height="70" alt="image" src="https://github.com/user-attachments/assets/8c598093-6a5b-4f0d-8d40-b861f95c9345" />

# Ops Impact

N/A

# Version Compatibility

N/A