### PR TITLE
[Backend] 광고 배포 목록 조회 / 광고 배포 세부정보 조회 API 구현

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/AdsController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/AdsController.java
@@ -76,6 +76,13 @@ public class AdsController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    /**
+     * 광고 배포 목록을 페이지네이션 방식으로 조회합니다.
+     *
+     * @param page  조회할 페이지 번호 (기본값: 1)
+     * @param limit 한 페이지당 데이터 개수 (기본값: 10)
+     * @return 페이지네이션 정보와 광고 배포 목록을 담은 응답 DTO
+     */
     @GetMapping("/deployment/list")
     public ResponseEntity<AdsDeploymentListDto> findAllDeploymentList(
             @RequestParam(defaultValue = "1") int page,
@@ -87,4 +94,10 @@ public class AdsController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    @GetMapping("/deployment/{id}")
+    public ResponseEntity<DetailAdsDeploymentDto> findDetailDeploymentById(@PathVariable Long id) {
+        DetailAdsDeploymentDto responseDto = deploymentService.findAdsDeploymentById(id);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/AdsController.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/controller/AdsController.java
@@ -75,4 +75,16 @@ public class AdsController {
         AdsDeploymentDto responseDto = deploymentService.deployAds(requestDto);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
+
+    @GetMapping("/deployment/list")
+    public ResponseEntity<AdsDeploymentListDto> findAllDeploymentList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        PaginationInfo paginationInfo = PaginationInfo.of(page, limit);
+        AdsDeploymentListDto responseDto = deploymentService.getAdsDeploymentList(paginationInfo);
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/Ads.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/Ads.java
@@ -1,0 +1,27 @@
+package com.coffee_is_essential.iot_cloud_ota.domain;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.AdsDeployment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Ads {
+    private Long id;
+    private String title;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime modifiedAt;
+
+    public static Ads from(AdsDeployment deployment) {
+        return new Ads(
+                deployment.getAdsMetadata().getId(),
+                deployment.getAdsMetadata().getTitle(),
+                deployment.getAdsMetadata().getCreatedAt(),
+                deployment.getAdsMetadata().getModifiedAt()
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/AdsDeploymentMetadata.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/domain/AdsDeploymentMetadata.java
@@ -1,0 +1,41 @@
+package com.coffee_is_essential.iot_cloud_ota.domain;
+
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareDeployment;
+import com.coffee_is_essential.iot_cloud_ota.enums.DeploymentType;
+import com.coffee_is_essential.iot_cloud_ota.enums.OverallStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdsDeploymentMetadata {
+    private Long id;
+    private DeploymentType deploymentType;
+    private List<Target> targetInfo;
+    private Long totalCount;
+    private Long successCount;
+    private Long inProgressCount;
+    private Long failedCount;
+    private OverallStatus status;
+    private OffsetDateTime deployedAt;
+
+    public static AdsDeploymentMetadata of(FirmwareDeployment deployment, List<Target> targetInfo, ProgressCount progressCount, OverallStatus overallStatus) {
+
+        return new AdsDeploymentMetadata(
+                deployment.getId(),
+                deployment.getDeploymentType(),
+                targetInfo,
+                progressCount.getTotalCount(),
+                progressCount.getSuccessCount(),
+                progressCount.getInProgressCount(),
+                progressCount.getFailedCount(),
+                overallStatus,
+                deployment.getDeployedAt()
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsDeploymentListDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/AdsDeploymentListDto.java
@@ -1,0 +1,23 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.domain.AdsDeploymentMetadata;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public record AdsDeploymentListDto(
+        List<AdsDeploymentMetadata> items,
+        PaginationMetadataDto paginationMeta
+) {
+    public static AdsDeploymentListDto of(List<AdsDeploymentMetadata> items, Pageable pageable, int totalPages, long totalElements) {
+        PaginationMetadataDto metadataDto = new PaginationMetadataDto(
+                pageable.getPageNumber() + 1,
+                pageable.getPageSize(),
+                totalPages,
+                totalElements
+        );
+
+        return new AdsDeploymentListDto(items, metadataDto);
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DetailAdsDeploymentDto.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/dto/DetailAdsDeploymentDto.java
@@ -1,0 +1,47 @@
+package com.coffee_is_essential.iot_cloud_ota.dto;
+
+import com.coffee_is_essential.iot_cloud_ota.domain.Ads;
+import com.coffee_is_essential.iot_cloud_ota.domain.DeviceDeploymentStatus;
+import com.coffee_is_essential.iot_cloud_ota.domain.ProgressCount;
+import com.coffee_is_essential.iot_cloud_ota.domain.Target;
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareDeployment;
+import com.coffee_is_essential.iot_cloud_ota.entity.OverallDeploymentStatus;
+import com.coffee_is_essential.iot_cloud_ota.enums.DeploymentType;
+import com.coffee_is_essential.iot_cloud_ota.enums.OverallStatus;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record DetailAdsDeploymentDto(
+        Long id,
+        String commandId,
+        List<Ads> ads,
+        DeploymentType deploymentType,
+        List<Target> targetInfo,
+        Long totalCount,
+        Long successCount,
+        Long inProgressCount,
+        Long failedCount,
+        OverallStatus status,
+        OffsetDateTime deployedAt,
+        OffsetDateTime expiresAt,
+        List<DeviceDeploymentStatus> devices
+) {
+    public static DetailAdsDeploymentDto of(FirmwareDeployment deployment, List<Target> targetInfo, List<DeviceDeploymentStatus> devices, ProgressCount progressCount, OverallDeploymentStatus status, List<Ads> ads) {
+        return new DetailAdsDeploymentDto(
+                deployment.getId(),
+                deployment.getCommandId(),
+                ads,
+                deployment.getDeploymentType(),
+                targetInfo,
+                progressCount.getTotalCount(),
+                progressCount.getSuccessCount(),
+                progressCount.getInProgressCount(),
+                progressCount.getFailedCount(),
+                status.getOverallStatus(),
+                deployment.getDeployedAt(),
+                deployment.getExpiresAt(),
+                devices
+        );
+    }
+}

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/AdsDeploymentJpaRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/AdsDeploymentJpaRepository.java
@@ -1,9 +1,13 @@
 package com.coffee_is_essential.iot_cloud_ota.repository;
 
 import com.coffee_is_essential.iot_cloud_ota.entity.AdsDeployment;
+import com.coffee_is_essential.iot_cloud_ota.entity.FirmwareDeployment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AdsDeploymentJpaRepository extends JpaRepository<AdsDeployment, Long> {
+    List<AdsDeployment> findByFirmwareDeployment(FirmwareDeployment firmwareDeployment);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareDeploymentRepository.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/repository/FirmwareDeploymentRepository.java
@@ -23,4 +23,6 @@ public interface FirmwareDeploymentRepository extends JpaRepository<FirmwareDepl
     }
 
     Page<FirmwareDeployment> findAllByFirmwareMetadataIsNotNull(Pageable pageable);
+
+    Page<FirmwareDeployment> findAllByFirmwareMetadataIsNull(Pageable pageable);
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentService.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeploymentService.java
@@ -169,6 +169,7 @@ public class DeploymentService {
                 OffsetDateTime.now()
         );
 
+        saveFirmwareDeploymentDevices(devices, firmwareDeployment, DeploymentStatus.IN_PROGRESS);
         List<DeployTargetDeviceInfo> deviceInfos = devices
                 .stream()
                 .map(DeployTargetDeviceInfo::from)
@@ -321,6 +322,22 @@ public class DeploymentService {
                 .toList();
 
         return DetailDeploymentResponseDto.of(deployment, targetInfo, downloadEvents, progressCount, status);
+    }
+
+    public DetailAdsDeploymentDto findAdsDeploymentById(Long id) {
+        FirmwareDeployment deployment = firmwareDeploymentRepository.findByIdOrElseThrow(id);
+        OverallDeploymentStatus status = overallDeploymentStatusRepository.findLatestByDeploymentIdOrElseThrow(id);
+        List<Target> targetInfo = getTargetList(deployment);
+        ProgressCount progressCount = getProgressCount(id);
+        List<DeviceDeploymentStatus> downloadEvents = downloadEventsJdbcRepository.findLatestPerDeviceByCommandId(deployment.getCommandId()).stream()
+                .map(DeviceDeploymentStatus::from)
+                .toList();
+
+        List<Ads> adsList = adsDeploymentJpaRepository.findByFirmwareDeployment(deployment).stream()
+                .map(Ads::from)
+                .toList();
+
+        return DetailAdsDeploymentDto.of(deployment, targetInfo, downloadEvents, progressCount, status, adsList);
     }
 
     /**


### PR DESCRIPTION
# Changelog

- 광고 배포 목록 조회 API 구현 (`api/ads/deployment/list`)
- 광고 배포 세부정보 조회 API 구현 (`api/ads/deployment/{id}`)

# Testing

- 로컬 환경에서 API 호출 후 정상적으로 목록과 페이징 정보 반환 확인
- 광고 배포 목록 조회
<img width="464" height="734" alt="image" src="https://github.com/user-attachments/assets/01d4688a-5986-468c-b988-c8063f4e3033" />

- 광고 배포 세부정보 조회
<img width="479" height="710" alt="image" src="https://github.com/user-attachments/assets/11156cf9-7bd4-4ca4-9f35-adfeaebfabe3" />


# Ops Impact

N/A

# Version Compatibility

N/A