### PR TITLE
[Backend] 배포 판정 로직에 ERROR 상태 추가

### DIFF
--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/enums/DeploymentStatus.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/enums/DeploymentStatus.java
@@ -1,5 +1,5 @@
 package com.coffee_is_essential.iot_cloud_ota.enums;
 
 public enum DeploymentStatus {
-    IN_PROGRESS, SUCCESS, FAILED, TIMEOUT, CANCELLED
+    IN_PROGRESS, SUCCESS, FAILED, TIMEOUT, CANCELLED, ERROR
 }

--- a/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
+++ b/backend/iot-cloud-ota/src/main/java/com/coffee_is_essential/iot_cloud_ota/service/DeployJudgeScheduler.java
@@ -209,6 +209,6 @@ public class DeployJudgeScheduler {
      */
     private boolean isCompleted(String deploymentStatus) {
         return deploymentStatus.equals(DeploymentStatus.SUCCESS.name()) || deploymentStatus.equals(DeploymentStatus.FAILED.name())
-               || deploymentStatus.equals(DeploymentStatus.CANCELLED.name()) || deploymentStatus.equals(DeploymentStatus.TIMEOUT.name());
+               || deploymentStatus.equals(DeploymentStatus.CANCELLED.name()) || deploymentStatus.equals(DeploymentStatus.TIMEOUT.name()) || deploymentStatus.equals(DeploymentStatus.ERROR.name());
     }
 }


### PR DESCRIPTION
# Changelog
- 배포 판정 로직에서 `ERROR` 상태를 완료 상태로 포함하도록 수정

# Testing
- 로컬 환경에서 ERROR 상태 이벤트 발생 시 완료 처리되는지 확인
<img width="460" height="746" alt="image" src="https://github.com/user-attachments/assets/d9aa8a3d-2e3a-4e7b-b77f-9456497ecbd6" />


# Ops Impact
- N/A

# Version Compatibility
- N/A
